### PR TITLE
Remote RX Receiver & Remote TX Improvements

### DIFF
--- a/code/RemoteRx/RemoteRx.ino
+++ b/code/RemoteRx/RemoteRx.ino
@@ -1,0 +1,108 @@
+/**
+ * RC Transmitter – ESP32 / SX1280
+ * https://github.com/alx-uta/RC-Transmitter
+ * 
+ * Alex Uta
+ * microknot.dev
+ */
+
+// ESP32 specific files
+#include "soc/timer_group_struct.h"
+#include "soc/timer_group_reg.h"
+
+// User Custom Config
+#include "user_config.hpp"
+
+// Libraries
+#include <TFT_eSPI.h>
+#include <SPI.h>
+#include <RadioLib.h>
+
+// Custom Files
+#include "src/rx/rx.hpp"
+#include "src/tft/widgets/display_number/display_number.hpp"
+#include "src/tft/widgets/vertical_slider/vertical_slider.hpp"
+#include "src/tft/widgets/horizontal_slider/horizontal_slider.hpp"
+#include "src/tft/widgets/switch/switch.hpp"
+#include "src/tft/widgets/rotary_encoder/rotary_encoder.hpp"
+#include "src/tft/widgets/battery_icon/battery_icon.hpp"
+
+// Init and other files
+#include "src/init.hpp"
+#include "src/setup.hpp"
+
+
+/**
+* We'll use core:0 for TFT update and RX hopping
+*/
+void func_updateTFT( void * pvParameters ){
+    while(true){
+        // TFT Update
+        _RX.updateTftRemoteTX();
+
+        /**
+         * Radio Hopping
+         */
+        rxHopping();
+
+        feedTheDog();
+    }
+}
+
+/**
+ * We'll use core:1 to receive the data
+ */
+void func_txReceiveData( void * pvParameters ){
+    while(true){
+        /**
+         * Receive the data
+         */
+        receiveData();
+
+        /**
+         * Feed the dog
+         */
+        feedTheDog();
+    }
+}
+
+void setup() {
+    #if ENABLE_SERIAL_PRINT
+        Serial.begin(115200);
+    #endif
+
+    /**
+     * TFT setup
+     */
+    tft_setup();
+
+    /**
+     * SX1280 setup
+     */
+    SX1280_setup();
+
+    xTaskCreatePinnedToCore(
+        func_txReceiveData,
+        "task_txReceiveData",
+        100 * 1024,
+        NULL,
+        20,
+        &task_txReceiveData,
+        taskCore1
+    );
+
+    xTaskCreatePinnedToCore(
+        func_updateTFT,
+        "task_updateTFT",
+        100 * 1024,
+        NULL,
+        19,
+        &task_updateTFT,
+        taskCore2
+    );
+
+}
+
+
+void loop() {
+}

--- a/code/RemoteRx/example.user_config.hpp
+++ b/code/RemoteRx/example.user_config.hpp
@@ -1,0 +1,52 @@
+/**
+ * RC Transmitter – ESP32 / SX1280
+ * https://github.com/alx-uta/RC-Transmitter
+ * 
+ * Alex Uta
+ * microknot.dev
+ */
+
+#ifndef USER_CONFIG_HPP
+#define USER_CONFIG_HPP
+
+// Debug
+#define ENABLE_SERIAL_PRINT     true
+#define ENABLE_DEBUG            false
+#define ENABLE_RADIO_LIB_DEBUG  false
+
+/**
+ * SX1280
+ */
+
+/*!
+  \brief No shaping.
+*/
+#define RADIOLIB_SHAPING_NONE                                   (0x00)
+
+/*!
+  \brief Gaussian shaping filter, BT = 0.5
+*/
+#define RADIOLIB_SHAPING_0_5                                    (0x02)
+
+/*!
+  \brief Gaussian shaping filter, BT = 1.0
+*/
+#define RADIOLIB_SHAPING_1_0                                    (0x04)
+
+
+// This needs to be the same as the Remote TX
+float   SX1280_FREQUENCY                    = 2410; // Remote TX
+float   SX1280_TX_FREQUENCY                 = 2420; // External TX
+int     SX1280_FREQUENCY_DEVIATION          = 1500;
+int     SX1280_BIT_RATE                     = 250;
+int     SX1280_CODING_RATE                  = 5;
+int     SX1280_OUTPUT_POWER                 = 8; // -18 to 13 dBm
+int     SX1280_GAIN_CONTROL                 = 8; // 1 - 13
+uint8_t SX1280_DATA_SHAPING                 = RADIOLIB_SHAPING_0_5;
+uint8_t SX1280_SYNC_WORD[]                  = {0x01, 0x23, 0x45, 0x67};
+int     SX1280_CRC_VALUE                    = 1;
+int     SX1280_PREAMBLE_LENGTH              = 4;
+
+int SX1280_HOPPING_INTERNAL_MILLIS          = 3000;
+int SX1280_TX_FREQUENCY_AVAILABILITY_MILLIS = 5;
+#endif  // USER_CONFIG_HPP

--- a/code/RemoteRx/src/config/config.cpp
+++ b/code/RemoteRx/src/config/config.cpp
@@ -1,0 +1,11 @@
+/**
+ * RC Transmitter – ESP32 / SX1280
+ * https://github.com/alx-uta/RC-Transmitter
+ * 
+ * Alex Uta
+ * microknot.dev
+ */
+
+#include "config.hpp"
+
+Config::Config () {}

--- a/code/RemoteRx/src/config/config.hpp
+++ b/code/RemoteRx/src/config/config.hpp
@@ -1,0 +1,55 @@
+/**
+ * RC Transmitter – ESP32 / SX1280
+ * https://github.com/alx-uta/RC-Transmitter
+ * 
+ * Alex Uta
+ * microknot.dev
+ */
+
+#ifndef CONFIG_HPP
+#define CONFIG_HPP
+
+#include "Arduino.h"
+#include <TFT_eSPI.h>
+
+class Config {
+	public:
+		Config();
+        /**
+         * Generic Pinout
+         */
+        uint8_t SCK_PIN     = 14;
+        uint8_t MISO_PIN    = 12;
+        uint8_t MOSI_PIN    = 13;
+
+        /**
+         * SX1280 Init
+         */
+        uint8_t SX1280_NSS  = 2;
+        uint8_t SX1280_DI01 = 26;
+        uint8_t SX1280_NRST = 5;
+        uint8_t SX1280_BUSY = 21;
+
+        /**
+         * TFT
+         */
+        uint16_t TFT_BACKGROUND      = TFT_BLACK;
+        uint16_t TFT_SWITCH_ON       = TFT_GREEN;
+        uint16_t TFT_SWITCH_OFF      = TFT_RED;
+        uint16_t TFT_SWITCH_DISABLED = TFT_DARKGREY;
+
+        uint16_t TFT_ENCODER_BORDER_COLOUR = TFT_DARKGREY;
+        uint16_t TFT_ENCODER_FILL_COLOUR   = TFT_DARKGREY;
+        uint16_t TFT_ENCODER_ACTIV_COLOUR  = TFT_GREEN;
+
+        uint8_t pot_min = 0;
+        uint8_t pot_max = 255;
+        uint8_t joystick_min = 0;
+        uint8_t joystick_max = 255;
+
+        float SX1280_FREQUENCY;
+        float CURRENT_FREQUENCY;
+	private:
+};
+
+#endif  // CONFIG_HPP

--- a/code/RemoteRx/src/external_libs/User_Setup.h
+++ b/code/RemoteRx/src/external_libs/User_Setup.h
@@ -1,0 +1,383 @@
+//                            USER DEFINED SETTINGS
+//   Set driver type, fonts to be loaded, pins used and SPI control method etc
+//
+//   See the User_Setup_Select.h file if you wish to be able to define multiple
+//   setups and then easily select which setup file is used by the compiler.
+//
+//   If this file is edited correctly then all the library example sketches should
+//   run without the need to make any more changes for a particular hardware setup!
+//   Note that some sketches are designed for a particular TFT pixel width/height
+
+// User defined information reported by "Read_User_Setup" test & diagnostics example
+#define USER_SETUP_INFO "User_Setup"
+
+// Define to disable all #warnings in library (can be put in User_Setup_Select.h)
+//#define DISABLE_ALL_LIBRARY_WARNINGS
+
+// ##################################################################################
+//
+// Section 1. Call up the right driver file and any options for it
+//
+// ##################################################################################
+
+// Define STM32 to invoke optimised processor support (only for STM32)
+//#define STM32
+
+// Defining the STM32 board allows the library to optimise the performance
+// for UNO compatible "MCUfriend" style shields
+//#define NUCLEO_64_TFT
+//#define NUCLEO_144_TFT
+
+// STM32 8 bit parallel only:
+// If STN32 Port A or B pins 0-7 are used for 8 bit parallel data bus bits 0-7
+// then this will improve rendering performance by a factor of ~8x
+//#define STM_PORTA_DATA_BUS
+//#define STM_PORTB_DATA_BUS
+
+// Tell the library to use parallel mode (otherwise SPI is assumed)
+//#define TFT_PARALLEL_8_BIT
+//#defined TFT_PARALLEL_16_BIT // **** 16 bit parallel ONLY for RP2040 processor ****
+
+// Display type -  only define if RPi display
+//#define RPI_DISPLAY_TYPE // 20MHz maximum SPI
+
+// Only define one driver, the other ones must be commented out
+// #define ILI9341_DRIVER       // Generic driver for common displays
+//#define ILI9341_2_DRIVER     // Alternative ILI9341 driver, see https://github.com/Bodmer/TFT_eSPI/issues/1172
+//#define ST7735_DRIVER      // Define additional parameters below for this display
+//#define ILI9163_DRIVER     // Define additional parameters below for this display
+//#define S6D02A1_DRIVER
+//#define RPI_ILI9486_DRIVER // 20MHz maximum SPI
+//#define HX8357D_DRIVER
+//#define ILI9481_DRIVER
+//#define ILI9486_DRIVER
+//#define ILI9488_DRIVER     // WARNING: Do not connect ILI9488 display SDO to MISO if other devices share the SPI bus (TFT SDO does NOT tristate when CS is high)
+#define ST7789_DRIVER      // Full configuration option, define additional parameters below for this display
+//#define ST7789_2_DRIVER    // Minimal configuration option, define additional parameters below for this display
+//#define R61581_DRIVER
+//#define RM68140_DRIVER
+//#define ST7796_DRIVER
+//#define SSD1351_DRIVER
+//#define SSD1963_480_DRIVER
+//#define SSD1963_800_DRIVER
+//#define SSD1963_800ALT_DRIVER
+//#define ILI9225_DRIVER
+//#define GC9A01_DRIVER
+
+// Some displays support SPI reads via the MISO pin, other displays have a single
+// bi-directional SDA pin and the library will try to read this via the MOSI line.
+// To use the SDA line for reading data from the TFT uncomment the following line:
+
+#define TFT_SDA_READ      // This option is for ESP32 ONLY, tested with ST7789 and GC9A01 display only
+
+// For ST7735, ST7789 and ILI9341 ONLY, define the colour order IF the blue and red are swapped on your display
+// Try ONE option at a time to find the correct colour order for your display
+
+//  #define TFT_RGB_ORDER TFT_RGB  // Colour order Red-Green-Blue
+ #define TFT_RGB_ORDER TFT_BGR  // Colour order Blue-Green-Red
+
+// For M5Stack ESP32 module with integrated ILI9341 display ONLY, remove // in line below
+
+// #define M5STACK
+
+// For ST7789, ST7735, ILI9163 and GC9A01 ONLY, define the pixel width and height in portrait orientation
+// #define TFT_WIDTH  80
+// #define TFT_WIDTH  128
+// #define TFT_WIDTH  172 // ST7789 172 x 320
+#define TFT_WIDTH  240 // ST7789 240 x 240 and 240 x 320
+// #define TFT_HEIGHT 160
+// #define TFT_HEIGHT 128
+// #define TFT_HEIGHT 240 // ST7789 240 x 240
+#define TFT_HEIGHT 320 // ST7789 240 x 320
+// #define TFT_HEIGHT 240 // GC9A01 240 x 240
+
+// For ST7735 ONLY, define the type of display, originally this was based on the
+// colour of the tab on the screen protector film but this is not always true, so try
+// out the different options below if the screen does not display graphics correctly,
+// e.g. colours wrong, mirror images, or stray pixels at the edges.
+// Comment out ALL BUT ONE of these options for a ST7735 display driver, save this
+// this User_Setup file, then rebuild and upload the sketch to the board again:
+
+// #define ST7735_INITB
+// #define ST7735_GREENTAB
+// #define ST7735_GREENTAB2
+// #define ST7735_GREENTAB3
+// #define ST7735_GREENTAB128    // For 128 x 128 display
+// #define ST7735_GREENTAB160x80 // For 160 x 80 display (BGR, inverted, 26 offset)
+// #define ST7735_ROBOTLCD       // For some RobotLCD arduino shields (128x160, BGR, https://docs.arduino.cc/retired/getting-started-guides/TFT)
+// #define ST7735_REDTAB
+// #define ST7735_BLACKTAB
+// #define ST7735_REDTAB160x80   // For 160 x 80 display with 24 pixel offset
+
+// If colours are inverted (white shows as black) then uncomment one of the next
+// 2 lines try both options, one of the options should correct the inversion.
+
+// #define TFT_INVERSION_ON
+// #define TFT_INVERSION_OFF
+
+
+// ##################################################################################
+//
+// Section 2. Define the pins that are used to interface with the display here
+//
+// ##################################################################################
+
+// If a backlight control signal is available then define the TFT_BL pin in Section 2
+// below. The backlight will be turned ON when tft.begin() is called, but the library
+// needs to know if the LEDs are ON with the pin HIGH or LOW. If the LEDs are to be
+// driven with a PWM signal or turned OFF/ON then this must be handled by the user
+// sketch. e.g. with digitalWrite(TFT_BL, LOW);
+
+#define TFT_BL   27            // LED back-light control pin
+#define TFT_BACKLIGHT_ON HIGH  // Level to turn ON back-light (HIGH or LOW)
+
+
+
+// We must use hardware SPI, a minimum of 3 GPIO pins is needed.
+// Typical setup for ESP8266 NodeMCU ESP-12 is :
+//
+// Display SDO/MISO  to NodeMCU pin D6 (or leave disconnected if not reading TFT)
+// Display LED       to NodeMCU pin VIN (or 5V, see below)
+// Display SCK       to NodeMCU pin D5
+// Display SDI/MOSI  to NodeMCU pin D7
+// Display DC (RS/AO)to NodeMCU pin D3
+// Display RESET     to NodeMCU pin D4 (or RST, see below)
+// Display CS        to NodeMCU pin D8 (or GND, see below)
+// Display GND       to NodeMCU pin GND (0V)
+// Display VCC       to NodeMCU 5V or 3.3V
+//
+// The TFT RESET pin can be connected to the NodeMCU RST pin or 3.3V to free up a control pin
+//
+// The DC (Data Command) pin may be labelled AO or RS (Register Select)
+//
+// With some displays such as the ILI9341 the TFT CS pin can be connected to GND if no more
+// SPI devices (e.g. an SD Card) are connected, in this case comment out the #define TFT_CS
+// line below so it is NOT defined. Other displays such at the ST7735 require the TFT CS pin
+// to be toggled during setup, so in these cases the TFT_CS line must be defined and connected.
+//
+// The NodeMCU D0 pin can be used for RST
+//
+//
+// Note: only some versions of the NodeMCU provide the USB 5V on the VIN pin
+// If 5V is not available at a pin you can use 3.3V but backlight brightness
+// will be lower.
+
+
+// ###### EDIT THE PIN NUMBERS IN THE LINES FOLLOWING TO SUIT YOUR ESP8266 SETUP ######
+
+// For NodeMCU - use pin numbers in the form PIN_Dx where Dx is the NodeMCU pin designation
+// #define TFT_CS   PIN_D8  // Chip select control pin D8
+// #define TFT_DC   PIN_D3  // Data Command control pin
+// #define TFT_RST  PIN_D4  // Reset pin (could connect to NodeMCU RST, see next line)
+//#define TFT_RST  -1    // Set TFT_RST to -1 if the display RESET is connected to NodeMCU RST or 3.3V
+
+//#define TFT_BL PIN_D1  // LED back-light (only for ST7789 with backlight control pin)
+
+//#define TOUCH_CS PIN_D2     // Chip select pin (T_CS) of touch screen
+
+//#define TFT_WR PIN_D2       // Write strobe for modified Raspberry Pi TFT only
+
+
+// ######  FOR ESP8266 OVERLAP MODE EDIT THE PIN NUMBERS IN THE FOLLOWING LINES  ######
+
+// Overlap mode shares the ESP8266 FLASH SPI bus with the TFT so has a performance impact
+// but saves pins for other functions. It is best not to connect MISO as some displays
+// do not tristate that line when chip select is high!
+// Note: Only one SPI device can share the FLASH SPI lines, so a SPI touch controller
+// cannot be connected as well to the same SPI signals.
+// On NodeMCU 1.0 SD0=MISO, SD1=MOSI, CLK=SCLK to connect to TFT in overlap mode
+// On NodeMCU V3  S0 =MISO, S1 =MOSI, S2 =SCLK
+// In ESP8266 overlap mode the following must be defined
+
+//#define TFT_SPI_OVERLAP
+
+// In ESP8266 overlap mode the TFT chip select MUST connect to pin D3
+//#define TFT_CS   PIN_D3
+//#define TFT_DC   PIN_D5  // Data Command control pin
+//#define TFT_RST  PIN_D4  // Reset pin (could connect to NodeMCU RST, see next line)
+//#define TFT_RST  -1  // Set TFT_RST to -1 if the display RESET is connected to NodeMCU RST or 3.3V
+
+
+// ###### EDIT THE PIN NUMBERS IN THE LINES FOLLOWING TO SUIT YOUR ESP32 SETUP   ######
+
+// For ESP32 Dev board (only tested with ILI9341 display)
+// The hardware SPI can be mapped to any pins
+
+#define TFT_MISO -1
+#define TFT_MOSI 13
+#define TFT_SCLK 14
+#define TFT_CS   25  // Chip select control pin
+#define TFT_DC    4  // Data Command control pin
+#define TFT_RST   15  // Reset pin (could connect to RST pin)
+//#define TFT_RST  -1  // Set TFT_RST to -1 if display RESET is connected to ESP32 board RST
+
+// For ESP32 Dev board (only tested with GC9A01 display)
+// The hardware SPI can be mapped to any pins
+
+//#define TFT_MOSI 15 // In some display driver board, it might be written as "SDA" and so on.
+//#define TFT_SCLK 14
+//#define TFT_CS   5  // Chip select control pin
+//#define TFT_DC   27  // Data Command control pin
+//#define TFT_RST  33  // Reset pin (could connect to Arduino RESET pin)
+//#define TFT_BL   22  // LED back-light
+
+//#define TOUCH_CS 21     // Chip select pin (T_CS) of touch screen
+
+//#define TFT_WR 22    // Write strobe for modified Raspberry Pi TFT only
+
+// For the M5Stack module use these #define lines
+//#define TFT_MISO 19
+//#define TFT_MOSI 23
+//#define TFT_SCLK 18
+//#define TFT_CS   14  // Chip select control pin
+//#define TFT_DC   27  // Data Command control pin
+//#define TFT_RST  33  // Reset pin (could connect to Arduino RESET pin)
+//#define TFT_BL   32  // LED back-light (required for M5Stack)
+
+// ######       EDIT THE PINs BELOW TO SUIT YOUR ESP32 PARALLEL TFT SETUP        ######
+
+// The library supports 8 bit parallel TFTs with the ESP32, the pin
+// selection below is compatible with ESP32 boards in UNO format.
+// Wemos D32 boards need to be modified, see diagram in Tools folder.
+// Only ILI9481 and ILI9341 based displays have been tested!
+
+// Parallel bus is only supported for the STM32 and ESP32
+// Example below is for ESP32 Parallel interface with UNO displays
+
+// Tell the library to use 8 bit parallel mode (otherwise SPI is assumed)
+//#define TFT_PARALLEL_8_BIT
+
+// The ESP32 and TFT the pins used for testing are:
+//#define TFT_CS   33  // Chip select control pin (library pulls permanently low
+//#define TFT_DC   15  // Data Command control pin - must use a pin in the range 0-31
+//#define TFT_RST  32  // Reset pin, toggles on startup
+
+//#define TFT_WR    4  // Write strobe control pin - must use a pin in the range 0-31
+//#define TFT_RD    2  // Read strobe control pin
+
+//#define TFT_D0   12  // Must use pins in the range 0-31 for the data bus
+//#define TFT_D1   13  // so a single register write sets/clears all bits.
+//#define TFT_D2   26  // Pins can be randomly assigned, this does not affect
+//#define TFT_D3   25  // TFT screen update performance.
+//#define TFT_D4   17
+//#define TFT_D5   16
+//#define TFT_D6   27
+//#define TFT_D7   14
+
+// ######       EDIT THE PINs BELOW TO SUIT YOUR STM32 SPI TFT SETUP        ######
+
+// The TFT can be connected to SPI port 1 or 2
+//#define TFT_SPI_PORT 1 // SPI port 1 maximum clock rate is 55MHz
+//#define TFT_MOSI PA7
+//#define TFT_MISO PA6
+//#define TFT_SCLK PA5
+
+//#define TFT_SPI_PORT 2 // SPI port 2 maximum clock rate is 27MHz
+//#define TFT_MOSI PB15
+//#define TFT_MISO PB14
+//#define TFT_SCLK PB13
+
+// Can use Ardiuno pin references, arbitrary allocation, TFT_eSPI controls chip select
+//#define TFT_CS   D5 // Chip select control pin to TFT CS
+//#define TFT_DC   D6 // Data Command control pin to TFT DC (may be labelled RS = Register Select)
+//#define TFT_RST  D7 // Reset pin to TFT RST (or RESET)
+// OR alternatively, we can use STM32 port reference names PXnn
+//#define TFT_CS   PE11 // Nucleo-F767ZI equivalent of D5
+//#define TFT_DC   PE9  // Nucleo-F767ZI equivalent of D6
+//#define TFT_RST  PF13 // Nucleo-F767ZI equivalent of D7
+
+//#define TFT_RST  -1   // Set TFT_RST to -1 if the display RESET is connected to processor reset
+                        // Use an Arduino pin for initial testing as connecting to processor reset
+                        // may not work (pulse too short at power up?)
+
+// ##################################################################################
+//
+// Section 3. Define the fonts that are to be used here
+//
+// ##################################################################################
+
+// Comment out the #defines below with // to stop that font being loaded
+// The ESP8366 and ESP32 have plenty of memory so commenting out fonts is not
+// normally necessary. If all fonts are loaded the extra FLASH space required is
+// about 17Kbytes. To save FLASH space only enable the fonts you need!
+
+// #define LOAD_GLCD   // Font 1. Original Adafruit 8 pixel font needs ~1820 bytes in FLASH
+#define LOAD_FONT2  // Font 2. Small 16 pixel high font, needs ~3534 bytes in FLASH, 96 characters
+#define LOAD_FONT4  // Font 4. Medium 26 pixel high font, needs ~5848 bytes in FLASH, 96 characters
+// #define LOAD_FONT6  // Font 6. Large 48 pixel font, needs ~2666 bytes in FLASH, only characters 1234567890:-.apm
+#define LOAD_FONT7  // Font 7. 7 segment 48 pixel font, needs ~2438 bytes in FLASH, only characters 1234567890:-.
+// #define LOAD_FONT8  // Font 8. Large 75 pixel font needs ~3256 bytes in FLASH, only characters 1234567890:-.
+//#define LOAD_FONT8N // Font 8. Alternative to Font 8 above, slightly narrower, so 3 digits fit a 160 pixel TFT
+// #define LOAD_GFXFF  // FreeFonts. Include access to the 48 Adafruit_GFX free fonts FF1 to FF48 and custom fonts
+
+// Comment out the #define below to stop the SPIFFS filing system and smooth font code being loaded
+// this will save ~20kbytes of FLASH
+#define SMOOTH_FONT
+
+
+// ##################################################################################
+//
+// Section 4. Other options
+//
+// ##################################################################################
+
+// For RP2040 processor and SPI displays, uncomment the following line to use the PIO interface.
+//#define RP2040_PIO_SPI // Leave commented out to use standard RP2040 SPI port interface
+
+// For RP2040 processor and 8 or 16 bit parallel displays:
+// The parallel interface write cycle period is derived from a division of the CPU clock
+// speed so scales with the processor clock. This means that the divider ratio may need
+// to be increased when overclocking. I may also need to be adjusted dependant on the
+// display controller type (ILI94341, HX8357C etc). If RP2040_PIO_CLK_DIV is not defined
+// the library will set default values which may not suit your display.
+// The display controller data sheet will specify the minimum write cycle period. The
+// controllers often work reliably for shorter periods, however if the period is too short
+// the display may not initialise or graphics will become corrupted.
+// PIO write cycle frequency = (CPU clock/(4 * RP2040_PIO_CLK_DIV))
+//#define RP2040_PIO_CLK_DIV 1 // 32ns write cycle at 125MHz CPU clock
+//#define RP2040_PIO_CLK_DIV 2 // 64ns write cycle at 125MHz CPU clock
+//#define RP2040_PIO_CLK_DIV 3 // 96ns write cycle at 125MHz CPU clock
+
+// For the RP2040 processor define the SPI port channel used (default 0 if undefined)
+//#define TFT_SPI_PORT 1 // Set to 0 if SPI0 pins are used, or 1 if spi1 pins used
+
+// For the STM32 processor define the SPI port channel used (default 1 if undefined)
+//#define TFT_SPI_PORT 2 // Set to 1 for SPI port 1, or 2 for SPI port 2
+
+// Define the SPI clock frequency, this affects the graphics rendering speed. Too
+// fast and the TFT driver will not keep up and display corruption appears.
+// With an ILI9341 display 40MHz works OK, 80MHz sometimes fails
+// With a ST7735 display more than 27MHz may not work (spurious pixels and lines)
+// With an ILI9163 display 27 MHz works OK.
+
+// #define SPI_FREQUENCY   1000000
+// #define SPI_FREQUENCY   5000000
+// #define SPI_FREQUENCY  10000000
+// #define SPI_FREQUENCY  20000000
+// #define SPI_FREQUENCY  27000000
+#define SPI_FREQUENCY  40000000
+// #define SPI_FREQUENCY  55000000 // STM32 SPI1 only (SPI2 maximum is 27MHz)
+// #define SPI_FREQUENCY  80000000
+
+// Optional reduced SPI frequency for reading TFT
+// #define SPI_READ_FREQUENCY  20000000
+
+// The XPT2046 requires a lower SPI clock rate of 2.5MHz so we define that here:
+// #define SPI_TOUCH_FREQUENCY  2500000
+
+// The ESP32 has 2 free SPI ports i.e. VSPI and HSPI, the VSPI is the default.
+// If the VSPI port is in use and pins are not accessible (e.g. TTGO T-Beam)
+// then uncomment the following line:
+#define USE_HSPI_PORT
+
+// Comment out the following #define if "SPI Transactions" do not need to be
+// supported. When commented out the code size will be smaller and sketches will
+// run slightly faster, so leave it commented out unless you need it!
+
+// Transaction support is needed to work with SD library but not needed with TFT_SdFat
+// Transaction support is required if other SPI devices are connected.
+
+// Transactions are automatically enabled by the library for an ESP32 (to use HAL mutex)
+// so changing it here has no effect
+
+// #define SUPPORT_TRANSACTIONS

--- a/code/RemoteRx/src/init.hpp
+++ b/code/RemoteRx/src/init.hpp
@@ -1,0 +1,194 @@
+/**
+ * RC Transmitter – ESP32 / SX1280
+ * https://github.com/alx-uta/RC-Transmitter
+ * 
+ * Alex Uta
+ * microknot.dev
+ */
+
+Config _RX_CONFIG;
+
+/**
+ * RadioLib Init
+ * 
+ * This is used to transmit the data
+ */
+SX1280 radio = new Module(
+  _RX_CONFIG.SX1280_NSS,
+  _RX_CONFIG.SX1280_DI01,
+  _RX_CONFIG.SX1280_NRST,
+  _RX_CONFIG.SX1280_BUSY
+);
+
+// flag to indicate that a packet was received
+volatile bool receivedFlag = false;
+
+// disable interrupt when it's not needed
+volatile bool enableInterrupt = true;
+
+// this function is called when a complete packet
+// is received by the module
+// IMPORTANT: this function MUST be 'void' type
+//            and MUST NOT have any arguments!
+#if defined(ESP8266) || defined(ESP32)
+  ICACHE_RAM_ATTR
+#endif
+void setFlag(void) {
+  // check if the interrupt is enabled
+  if(!enableInterrupt) {
+    return;
+  }
+
+  // we got a packet, set the flag
+  receivedFlag = true;
+}
+
+/**
+ * Define the tasks and cores
+ */
+static int taskCore1 = 0;
+TaskHandle_t task_txReceiveData;
+
+static int taskCore2 = 1;
+TaskHandle_t task_updateTFT;
+
+/**
+ * TFT init
+ */
+TFT_eSPI tft = TFT_eSPI();
+
+// Battery Icons
+BatteryIcon _TX_BATTERY(
+    _RX_CONFIG, tft, 0, 0, 30
+);
+BatteryIcon _RX_BATTERY(
+    _RX_CONFIG, tft, 290, 0, 30
+);
+
+// Rotary Encoder - Display Position
+DisplayNumber _DISPLAY_POSITION_LEFT(
+    _RX_CONFIG, tft, 25, 205
+);
+DisplayNumber _DISPLAY_POSITION_RIGHT(
+    _RX_CONFIG, tft, 203, 205
+);
+
+// Joysticks
+HorizontalSlider _LEFT_JOYSTICK_X(
+    _RX_CONFIG, tft, 0, 0, 0, 255, 145
+);
+VerticalSlider _LEFT_JOYSTICK_Y(
+    _RX_CONFIG, tft, 0, 0, 0, 255, 205, 40, 7, 5
+);
+
+HorizontalSlider _RIGHT_JOYSTICK_X(
+    _RX_CONFIG, tft, 30 + 140, 0, 0, 255, 145
+);
+VerticalSlider _RIGHT_JOYSTICK_Y(
+    _RX_CONFIG, tft, 313, 0, 0, 255, 205, 40, 7, 5
+);
+
+// Potentiometers
+VerticalSlider _SLIDER_POT_1(
+    _RX_CONFIG, tft, 30, 0, 255, 0, 90, 40, 7, 5
+);
+VerticalSlider _SLIDER_POT_2(
+    _RX_CONFIG, tft, 45, 0, 255, 0, 90, 40, 7, 5
+);
+VerticalSlider _SLIDER_POT_3(
+    _RX_CONFIG, tft, 60, 0, 255, 0, 90, 40, 7, 5
+);
+VerticalSlider _SLIDER_POT_4(
+    _RX_CONFIG, tft, 75, 0, 255, 0, 90, 40, 7, 5
+);
+VerticalSlider _SLIDER_POT_5(
+    _RX_CONFIG, tft, 147, 0, 255, 0, 190, 125, 7, 5
+);
+VerticalSlider _SLIDER_POT_6(
+    _RX_CONFIG, tft, 162, 0, 255, 0, 190, 125, 7, 5
+);
+
+VerticalSlider pots[6] = {
+    _SLIDER_POT_1,
+    _SLIDER_POT_2,
+    _SLIDER_POT_3,
+    _SLIDER_POT_4,
+    _SLIDER_POT_5,
+    _SLIDER_POT_6
+};
+
+// Switches
+Switch _S1(_RX_CONFIG, tft, 200, 40, 0);
+Switch _S2(_RX_CONFIG, tft, 200, 40, 1);
+Switch _S3(_RX_CONFIG, tft, 200, 40, 2);
+Switch _S4(_RX_CONFIG, tft, 200, 40, 3);
+Switch _S5(_RX_CONFIG, tft, 200, 40, 4);
+
+Switch switches[5] = {
+    _S1,
+    _S2,
+    _S3,
+    _S4,
+    _S5
+};
+
+// Rotary Encoder
+RotaryEncoder _ENCODER_LEFT(_RX_CONFIG, tft, 72, 155);
+RotaryEncoder _ENCODER_RIGHT(_RX_CONFIG, tft, 250, 155);
+
+/**
+ *
+ * RX init
+ */
+Rx _RX(
+    // Config
+    _RX_CONFIG,
+    
+    // TFT Screen
+    tft,
+    
+    // TX/RX Battery
+    _TX_BATTERY,
+    _RX_BATTERY,
+    
+    // Left Rotary Encoder
+    _DISPLAY_POSITION_LEFT,
+    _ENCODER_LEFT,
+
+    // Right Rotary Encoder
+    _DISPLAY_POSITION_RIGHT,
+    _ENCODER_RIGHT,
+
+    // Left Joystick
+    _LEFT_JOYSTICK_X,
+    _LEFT_JOYSTICK_Y,
+    
+    // Right Joystick
+    _RIGHT_JOYSTICK_X,
+    _RIGHT_JOYSTICK_Y,
+    
+    // Potentiometers
+    _SLIDER_POT_1,
+    _SLIDER_POT_2,
+    _SLIDER_POT_3,
+    _SLIDER_POT_4,
+    _SLIDER_POT_5,
+    _SLIDER_POT_6,
+
+    // Switches
+    _S1,
+    _S2,
+    _S3,
+    _S4,
+    _S5
+);
+
+const int _payload_size = 21;
+uint8_t _payload[_payload_size];
+
+/**
+ * Frequency hopping settings
+ */
+float current_frequency;
+unsigned long current_time;
+unsigned long last_switch_time = millis();

--- a/code/RemoteRx/src/rx/rx.cpp
+++ b/code/RemoteRx/src/rx/rx.cpp
@@ -1,0 +1,197 @@
+/**
+ * RC Transmitter – ESP32 / SX1280
+ * https://github.com/alx-uta/RC-Transmitter
+ * 
+ * Alex Uta
+ * microknot.dev
+ */
+
+#include "rx.hpp"
+
+Rx::Rx(
+    Config& config,
+    TFT_eSPI& tft,
+
+    // TX/RX Battery
+    BatteryIcon& TX_BATTERY,
+    BatteryIcon& RX_BATTERY,
+    
+    // Left Rotary Encoder
+    DisplayNumber& DISPLAY_POSITION_LEFT,
+    RotaryEncoder& ENCODER_LEFT,
+
+    // Right Rotary Encoder
+    DisplayNumber& DISPLAY_POSITION_RIGHT,
+    RotaryEncoder& ENCODER_RIGHT,
+
+    // Left Joystick
+    HorizontalSlider& LEFT_JOYSTICK_X,
+    VerticalSlider& LEFT_JOYSTICK_Y,
+    
+    // Right Joystick
+    HorizontalSlider& RIGHT_JOYSTICK_X,
+    VerticalSlider& RIGHT_JOYSTICK_Y,
+    
+    // Potentiometers
+    VerticalSlider& SLIDER_POT_1,
+    VerticalSlider& SLIDER_POT_2,
+    VerticalSlider& SLIDER_POT_3,
+    VerticalSlider& SLIDER_POT_4,
+    VerticalSlider& SLIDER_POT_5,
+    VerticalSlider& SLIDER_POT_6,
+
+    // Switches
+    Switch& S1,
+    Switch& S2,
+    Switch& S3,
+    Switch& S4,
+    Switch& S5
+)
+    :   _config(config),
+        _tft(tft),
+
+        // TX/RX Battery
+        _TX_BATTERY(TX_BATTERY),
+        _RX_BATTERY(RX_BATTERY),
+        
+        // Left Rotary Encoder
+        _DISPLAY_POSITION_LEFT(DISPLAY_POSITION_LEFT),
+        _ENCODER_LEFT(ENCODER_LEFT),
+
+        // Right Rotary Encoder
+        _DISPLAY_POSITION_RIGHT(DISPLAY_POSITION_RIGHT),
+        _ENCODER_RIGHT(ENCODER_RIGHT),
+
+        // Left Joystick
+        _LEFT_JOYSTICK_X(LEFT_JOYSTICK_X),
+        _LEFT_JOYSTICK_Y(LEFT_JOYSTICK_Y),
+        
+        // Right Joystick
+        _RIGHT_JOYSTICK_X(RIGHT_JOYSTICK_X),
+        _RIGHT_JOYSTICK_Y(RIGHT_JOYSTICK_Y),
+        
+        // Potentiometers
+        _SLIDER_POT_1(SLIDER_POT_1),
+        _SLIDER_POT_2(SLIDER_POT_2),
+        _SLIDER_POT_3(SLIDER_POT_3),
+        _SLIDER_POT_4(SLIDER_POT_4),
+        _SLIDER_POT_5(SLIDER_POT_5),
+        _SLIDER_POT_6(SLIDER_POT_6),
+
+        // Switches
+        _S1(S1),
+        _S2(S2),
+        _S3(S3),
+        _S4(S4),
+        _S5(S5)
+
+         {}
+
+/**
+ * Read and set the right values
+ */
+void Rx::setData(
+    uint8_t* _payload
+) {
+    if(_payload[0] == 1 and _config.CURRENT_FREQUENCY==_config.SX1280_FREQUENCY) {
+        Rx::setTXpayload(_payload);
+    }
+}
+
+void Rx::setTXpayload(uint8_t* _payload) {
+    memcpy(Rx::_payload.byteArray, _payload, sizeof(Rx::_payload.byteArray));
+}
+
+void Rx::updateTftRemoteTX() {
+    /**
+     * Joysticks
+     */
+    _LEFT_JOYSTICK_X.update(
+        constrain(
+            Rx::_payload.structure.j1x, _config.joystick_min, _config.joystick_max
+        )
+    );
+    _LEFT_JOYSTICK_Y.update(
+        constrain(
+            Rx::_payload.structure.j1y, _config.joystick_min, _config.joystick_max
+        )
+    );
+        
+    _RIGHT_JOYSTICK_X.update(
+        constrain(
+            Rx::_payload.structure.j2x, _config.joystick_min, _config.joystick_max
+        )
+    );
+    _RIGHT_JOYSTICK_Y.update(
+        constrain(
+            Rx::_payload.structure.j2y, _config.joystick_min, _config.joystick_max
+        )
+    );
+
+    /**
+     * Potentiometers
+     */
+    _SLIDER_POT_1.update(constrain(Rx::_payload.structure.p1,_config.pot_min,_config.pot_max));
+    _SLIDER_POT_2.update(constrain(Rx::_payload.structure.p2,_config.pot_min,_config.pot_max));
+    _SLIDER_POT_3.update(constrain(Rx::_payload.structure.p3,_config.pot_min,_config.pot_max));
+    _SLIDER_POT_4.update(constrain(Rx::_payload.structure.p4,_config.pot_min,_config.pot_max));
+    _SLIDER_POT_5.update(constrain(Rx::_payload.structure.p5,_config.pot_min,_config.pot_max));
+    _SLIDER_POT_6.update(constrain(Rx::_payload.structure.p6,_config.pot_min,_config.pot_max));
+
+    /**
+     * Rotary Encoders
+     */
+    _DISPLAY_POSITION_LEFT.update(
+        Rx::getAnoRotaryEncoderPosition(
+            Rx::_payload.structure.re1_pos_high,
+            Rx::_payload.structure.re1_pos_mid_high,
+            Rx::_payload.structure.re1_pos_mid_low,
+            Rx::_payload.structure.re1_pos_low
+        )
+    );
+
+    _DISPLAY_POSITION_RIGHT.update(
+        Rx::getAnoRotaryEncoderPosition(
+            Rx::_payload.structure.re2_pos_high,
+            Rx::_payload.structure.re2_pos_mid_high,
+            Rx::_payload.structure.re2_pos_mid_low,
+            Rx::_payload.structure.re2_pos_low
+        )
+    );
+
+    uint16_t combined_byte = Rx::combineBytes(
+        Rx::_payload.structure.switches_state_1, Rx::_payload.structure.switches_state_2
+    );
+
+    // Decode the uint16_t back into switch statuses
+    bool decoded_switch_statuses[15];
+    Rx::decodeByteToSwitchStatuses(combined_byte, decoded_switch_statuses, 15);
+
+    /**
+     * Switches
+     */
+    _S1.update(decoded_switch_statuses[0]);
+    _S2.update(decoded_switch_statuses[1]);
+    _S3.update(decoded_switch_statuses[2]);
+    _S4.update(decoded_switch_statuses[3]);
+    _S5.update(decoded_switch_statuses[4]);
+
+    /**
+     * Encoders
+     */
+    _ENCODER_LEFT.update(
+        decoded_switch_statuses[5],
+        decoded_switch_statuses[6],
+        decoded_switch_statuses[7],
+        decoded_switch_statuses[8],
+        decoded_switch_statuses[9]
+    );
+
+    _ENCODER_RIGHT.update(
+        decoded_switch_statuses[10],
+        decoded_switch_statuses[11],
+        decoded_switch_statuses[12],
+        decoded_switch_statuses[13],
+        decoded_switch_statuses[14]
+    );
+}

--- a/code/RemoteRx/src/rx/rx.hpp
+++ b/code/RemoteRx/src/rx/rx.hpp
@@ -1,0 +1,161 @@
+/**
+ * RC Transmitter – ESP32 / SX1280
+ * https://github.com/alx-uta/RC-Transmitter
+ * 
+ * Alex Uta
+ * microknot.dev
+ */
+
+#ifndef RX_HPP
+#define RX_HPP
+
+#include "../config/config.hpp"
+#include "../tft/widgets/battery_icon/battery_icon.hpp"
+#include "../tft/widgets/display_number/display_number.hpp"
+#include "../tft/widgets/rotary_encoder/rotary_encoder.hpp"
+#include "../tft/widgets/vertical_slider/vertical_slider.hpp"
+#include "../tft/widgets/horizontal_slider/horizontal_slider.hpp"
+#include "../tft/widgets/switch/switch.hpp"
+
+#include <TFT_eSPI.h>
+
+class Rx {
+ public:
+    Rx(
+        Config& config,
+        TFT_eSPI& tft,
+
+        // TX/RX Battery
+        BatteryIcon& _TX_BATTERY,
+        BatteryIcon& _RX_BATTERY,
+        
+        // Left Rotary Encoder
+        DisplayNumber& _DISPLAY_POSITION_LEFT,
+        RotaryEncoder& _ENCODER_LEFT,
+
+        // Right Rotary Encoder
+        DisplayNumber& _DISPLAY_POSITION_RIGHT,
+        RotaryEncoder& _ENCODER_RIGHT,
+
+        // Left Joystick
+        HorizontalSlider& _LEFT_JOYSTICK_X,
+        VerticalSlider& _LEFT_JOYSTICK_Y,
+        
+        // Right Joystick
+        HorizontalSlider& _RIGHT_JOYSTICK_X,
+        VerticalSlider& _RIGHT_JOYSTICK_Y,
+        
+        // Potentiometers
+        VerticalSlider& _SLIDER_POT_1,
+        VerticalSlider& _SLIDER_POT_2,
+        VerticalSlider& _SLIDER_POT_3,
+        VerticalSlider& _SLIDER_POT_4,
+        VerticalSlider& _SLIDER_POT_5,
+        VerticalSlider& _SLIDER_POT_6,
+
+        // Switches
+        Switch& _S1,
+        Switch& _S2,
+        Switch& _S3,
+        Switch& _S4,
+        Switch& _S5
+    );
+
+    void setData(uint8_t* _payload);
+    void setTXpayload(uint8_t* _payload);
+
+    void updateTftRemoteTX();
+
+    // Utils
+    int getAnoRotaryEncoderPosition(uint8_t high, uint8_t mid_high, uint8_t mid_low, uint8_t low);
+    void decodeByteToSwitchStatuses(uint16_t encodedByte, bool switchStatuses[], int numSwitches);
+    uint16_t combineBytes(uint8_t byte1, uint8_t byte2);
+
+    float valRound(float val);
+
+    // Payload
+    typedef struct package {
+        // Set the sender identifier
+        uint8_t sender; // left-right
+
+        // Left Joystick
+        uint8_t j1x; // left-right
+        uint8_t j1y; // up-down
+
+        // Right Joystick
+        uint8_t j2x; // left-right
+        uint8_t j2y; // up-down
+
+        // Potentiometers - Values
+        uint8_t p1;
+        uint8_t p2;
+        uint8_t p3;
+        uint8_t p4;
+        uint8_t p5;
+        uint8_t p6;
+
+        // Split re1_pos into individual bytes
+        uint8_t re1_pos_high;
+        uint8_t re1_pos_mid_high;
+        uint8_t re1_pos_mid_low;
+        uint8_t re1_pos_low;
+
+        // Split re2_pos into individual bytes
+        uint8_t re2_pos_high;
+        uint8_t re2_pos_mid_high;
+        uint8_t re2_pos_mid_low;
+        uint8_t re2_pos_low;
+
+        uint8_t switches_state_1;
+        uint8_t switches_state_2;
+    };
+
+    typedef union btPacket_t {
+        package structure;
+        uint8_t byteArray[21];
+    };
+    package payload;
+
+    btPacket_t _payload;
+
+ private:
+    Config& _config;
+    TFT_eSPI& _tft;
+
+    // TX/RX Battery
+    BatteryIcon& _TX_BATTERY;
+    BatteryIcon& _RX_BATTERY;
+    
+    // Left Rotary Encoder
+    DisplayNumber& _DISPLAY_POSITION_LEFT;
+    RotaryEncoder& _ENCODER_LEFT;
+
+    // Right Rotary Encoder
+    DisplayNumber& _DISPLAY_POSITION_RIGHT;
+    RotaryEncoder& _ENCODER_RIGHT;
+
+    // Left Joystick
+    HorizontalSlider& _LEFT_JOYSTICK_X;
+    VerticalSlider& _LEFT_JOYSTICK_Y;
+    
+    // Right Joystick
+    HorizontalSlider& _RIGHT_JOYSTICK_X;
+    VerticalSlider& _RIGHT_JOYSTICK_Y;
+    
+    // Potentiometers
+    VerticalSlider& _SLIDER_POT_1;
+    VerticalSlider& _SLIDER_POT_2;
+    VerticalSlider& _SLIDER_POT_3;
+    VerticalSlider& _SLIDER_POT_4;
+    VerticalSlider& _SLIDER_POT_5;
+    VerticalSlider& _SLIDER_POT_6;
+
+    // Switches
+    Switch& _S1;
+    Switch& _S2;
+    Switch& _S3;
+    Switch& _S4;
+    Switch& _S5;
+};
+
+#endif  // RX_HPP

--- a/code/RemoteRx/src/rx/rx_utils.cpp
+++ b/code/RemoteRx/src/rx/rx_utils.cpp
@@ -1,0 +1,35 @@
+/**
+ * RC Transmitter – ESP32 / SX1280
+ * https://github.com/alx-uta/RC-Transmitter
+ * 
+ * Alex Uta
+ * microknot.dev
+ */
+
+#include "rx.hpp"
+
+int Rx::getAnoRotaryEncoderPosition(
+    uint8_t high, uint8_t mid_high, uint8_t mid_low, uint8_t low
+) {
+    // Check if any of the input bytes are outside the valid range (0-255)
+    if (high > 255 || mid_high > 255 || mid_low > 255 || low > 255) {
+        return 0; // Data is corrupted, return 0
+    }
+    
+    // Reconstruct the int value from the stored bytes
+    return  (high << 24) | (mid_high << 16) | (mid_low << 8) | low;
+}
+
+void Rx::decodeByteToSwitchStatuses(uint16_t encodedByte, bool switchStatuses[], int numSwitches) {
+  for (int i = 0; i < numSwitches; i++) {
+    switchStatuses[i] = (encodedByte >> i) & 0x01;
+  }
+}
+
+uint16_t Rx::combineBytes(uint8_t byte1, uint8_t byte2) {
+  return ((uint16_t)byte2 << 8) | byte1;
+}
+
+float Rx::valRound(float val) {
+  return round(val * 100.0) / 100.0;
+}

--- a/code/RemoteRx/src/setup.hpp
+++ b/code/RemoteRx/src/setup.hpp
@@ -1,0 +1,186 @@
+/**
+ * RC Transmitter – ESP32 / SX1280
+ * https://github.com/alx-uta/RC-Transmitter
+ * 
+ * Alex Uta
+ * microknot.dev
+ */
+
+/**
+ * SX1280
+ */
+void SX1280_setup() {
+    int state = radio.beginGFSK();
+    #if ENABLE_SERIAL_PRINT
+        #if ENABLE_RADIO_LIB_DEBUG
+            if (state == RADIOLIB_ERR_NONE) {
+                Serial.println(F("success!"));
+            } else {
+                Serial.print(F("failed, code "));
+                Serial.println(state);
+                while (true);
+            }
+        #endif
+    #endif
+
+    // @todo: run a check for each state
+    state = radio.setOutputPower(SX1280_OUTPUT_POWER);
+    state = radio.setGainControl(SX1280_GAIN_CONTROL);
+    state = radio.setFrequency(SX1280_FREQUENCY);
+    state = radio.setFrequencyDeviation(SX1280_FREQUENCY_DEVIATION);
+    state = radio.setBitRate(SX1280_BIT_RATE);
+    state = radio.setCodingRate(SX1280_CODING_RATE);
+    state = radio.setDataShaping(SX1280_DATA_SHAPING);
+    state = radio.setCRC(SX1280_CRC_VALUE);
+    state = radio.setSyncWord(SX1280_SYNC_WORD, 4);
+    state = radio.setPreambleLength(SX1280_PREAMBLE_LENGTH);
+
+    #if ENABLE_SERIAL_PRINT
+        #if ENABLE_RADIO_LIB_DEBUG
+            if (state != RADIOLIB_ERR_NONE) {
+                Serial.print(F("Unable to set configuration, code "));
+                Serial.println(state);
+                while (true);
+            }
+        #endif
+    #endif
+
+    radio.setDio1Action(setFlag);
+    // start listening for FSK packets
+    state = radio.startReceive();
+
+    #if ENABLE_SERIAL_PRINT
+        #if ENABLE_RADIO_LIB_DEBUG
+            Serial.print(F("[SX1280] Starting to listen ... "));
+            if (state == RADIOLIB_ERR_NONE) {
+                Serial.println(F("success!"));
+            } else {
+                Serial.print(F("failed, code "));
+                Serial.println(state);
+                while (true);
+            }
+        #endif
+    #endif
+}
+
+/**
+ * SX1280 Data Receive
+ */
+void receiveData() {
+    if(receivedFlag) {
+      enableInterrupt = false;
+  
+      // reset flag
+      receivedFlag = false;
+
+      int state = radio.readData(_payload, _payload_size);
+      if (state == RADIOLIB_ERR_NONE) {
+        _RX.setData(
+            _payload
+        );
+      }
+
+    #if ENABLE_SERIAL_PRINT
+        #if ENABLE_RADIO_LIB_DEBUG
+            if (state == RADIOLIB_ERR_CRC_MISMATCH) {
+                // packet was received, but is malformed
+                Serial.println(F("CRC error!"));
+            } else if {
+                // some other error occurred
+                Serial.print(F("failed, code "));
+                Serial.println(state);
+            }
+        #endif
+
+        #if ENABLE_DEBUG
+            // Debug the payload
+            for(int i=0; i < _payload_size; i++)
+            {
+                Serial.print(_payload[i]);
+                if(i < _payload_size - 1) {
+                    Serial.print(" : "); 
+                }
+            }
+            Serial.println();
+        #endif
+    #endif
+      radio.startReceive();
+      enableInterrupt = true;
+    }
+}
+
+void rxHopping() {
+    current_time = millis();
+
+    if ((
+        current_time - last_switch_time
+    ) >= SX1280_HOPPING_INTERNAL_MILLIS and current_frequency!=SX1280_TX_FREQUENCY) {
+        
+        // Move to the External TX Frequency
+        current_frequency = SX1280_TX_FREQUENCY;
+        radio.setFrequency(current_frequency);
+
+        // Update last_switch_time to the current time to mark the last switch time
+        last_switch_time = current_time;
+    }
+
+    if ((
+        current_time - last_switch_time
+    ) >= SX1280_TX_FREQUENCY_AVAILABILITY_MILLIS and current_frequency!=SX1280_FREQUENCY) {
+        
+        // Move to the TX Frequency
+        current_frequency = SX1280_FREQUENCY;
+        radio.setFrequency(current_frequency);
+
+        // Update last_switch_time to the current time to mark the last switch time
+        last_switch_time = current_time;
+    }
+}
+
+/**
+ * TFT setup
+ */
+void tft_setup() {
+    tft.init();
+    tft.setRotation(1);
+    tft.fillScreen(
+        _RX_CONFIG.TFT_BACKGROUND
+    );
+
+    // Battery
+    _TX_BATTERY.init(-1);
+    _RX_BATTERY.init(-1);
+
+    // Rotary Encoders
+    _ENCODER_LEFT.init();
+    _DISPLAY_POSITION_LEFT.init();
+
+    _ENCODER_RIGHT.init();
+    _DISPLAY_POSITION_RIGHT.init();
+
+    // Joysticks
+    _LEFT_JOYSTICK_X.init();
+    _LEFT_JOYSTICK_Y.init();
+
+    _RIGHT_JOYSTICK_Y.init();
+    _RIGHT_JOYSTICK_X.init();
+
+    // Potentiometers
+    for (int i = 0; i < 6; i++) {
+        pots[i].init();
+    }
+
+    // Switches
+    for (int i = 0; i < 5; i++) {
+        switches[i].init();
+    }
+}
+
+/**
+ * Feed the dog
+ */
+void feedTheDog() {
+  TIMERG0.wdt_wprotect = TIMG_WDT_WKEY_VALUE;
+  TIMERG0.wdt_feed = 1;
+  TIMERG0.wdt_wprotect = 0;
+}

--- a/code/RemoteRx/src/tft/widgets/battery_icon/battery_icon.cpp
+++ b/code/RemoteRx/src/tft/widgets/battery_icon/battery_icon.cpp
@@ -1,0 +1,73 @@
+/**
+ * RC Transmitter – ESP32 / SX1280
+ * https://github.com/alx-uta/RC-Transmitter
+ * 
+ * Alex Uta
+ * microknot.dev
+ */
+
+#include "battery_icon.hpp"
+
+BatteryIcon::BatteryIcon(Config & config, TFT_eSPI & tft, int x, int y, int width)
+    :   _config(config),
+        _tft(tft) {
+            _x = x;
+            _y = y;
+            _width = width;
+        }
+
+void BatteryIcon::init() {
+    BatteryIcon::update(0);
+}
+
+void BatteryIcon::init(int percentage) {
+    BatteryIcon::update(percentage);
+}
+
+void BatteryIcon::update(int percentage) {
+    if(percentage == BatteryIcon::_old_value and !BatteryIcon::_widget_created) {
+        return;
+    }
+
+    BatteryIcon::_old_value = percentage;
+    BatteryIcon::_widget_created = true;
+
+    // Set a default border
+    int border_radius = 3;
+
+    // Reduced height
+    int height = BatteryIcon::_width / 2;
+
+    // Choose the color based on the percentage range
+    uint16_t fillColor;
+
+    if (percentage <= 0) {
+        // If percentage is 0 or negative, draw an empty battery (disabled)
+        _tft.drawRect(_x, _y, BatteryIcon::_width, height, TFT_RED);
+        return;
+    } else if (percentage <= 25) {
+        // Red for 0-25%
+        fillColor = TFT_RED;
+    } else if (percentage <= 50) {
+        // Yellow for 26-50%
+        fillColor = TFT_YELLOW;
+    } else {
+        // Green for above 50%
+        fillColor = TFT_GREEN;
+    }
+
+    // Calculate the inner width based on the percentage
+    int innerWidth = map(
+        percentage, 0, 100, 0, BatteryIcon::_width - 2 * border_radius
+    );
+
+    // Draw battery fill with the chosen color
+    _tft.fillRect(
+        _x + 1, _y + border_radius, innerWidth, height - 2 * border_radius, fillColor
+    );
+
+    // Draw battery outline
+    _tft.drawRect(
+        _x, _y, BatteryIcon::_width, height, TFT_WHITE
+    );
+}

--- a/code/RemoteRx/src/tft/widgets/battery_icon/battery_icon.hpp
+++ b/code/RemoteRx/src/tft/widgets/battery_icon/battery_icon.hpp
@@ -1,0 +1,32 @@
+/**
+ * RC Transmitter – ESP32 / SX1280
+ * https://github.com/alx-uta/RC-Transmitter
+ * 
+ * Alex Uta
+ * microknot.dev
+ */
+
+#ifndef BATTERY_ICON_HPP
+#define BATTERY_ICON_HPP
+
+#include "../../../config/config.hpp"
+#include <TFT_eSPI.h>
+
+class BatteryIcon {
+ public:
+    BatteryIcon(Config& config, TFT_eSPI& tft, int x, int y, int width);
+    int _x;
+    int _y;
+    int _width;
+    int _old_value;
+    bool _widget_created = false;
+    void init(int percentage);
+    void init();
+    void update(int percentage);
+
+ private:
+    Config& _config;
+    TFT_eSPI& _tft;
+};
+
+#endif  // BATTERY_ICON_HPP

--- a/code/RemoteRx/src/tft/widgets/display_number/display_number.cpp
+++ b/code/RemoteRx/src/tft/widgets/display_number/display_number.cpp
@@ -1,0 +1,61 @@
+/**
+ * RC Transmitter – ESP32 / SX1280
+ * https://github.com/alx-uta/RC-Transmitter
+ * 
+ * Alex Uta
+ * microknot.dev
+ */
+
+#include "display_number.hpp"
+
+DisplayNumber::DisplayNumber(Config & config, TFT_eSPI & tft, int x, int y)
+    :   _config(config),
+        _tft(tft) {
+            _x = x;
+            _y = y;
+        }
+
+void DisplayNumber::init() {
+    DisplayNumber::update(0);
+}
+
+void DisplayNumber::update(int number) {
+  // Set text color and size
+  _tft.setTextColor(number != 0 ? TFT_LIGHTGREY : TFT_DARKGREY);
+  _tft.setTextSize(2);
+
+  if (number != DisplayNumber::_old_value or not DisplayNumber::_widget_created) {
+    DisplayNumber::_widget_created = true;
+
+    // Calculate the number of digits
+    int numDigits = max(8, int(log10(abs(number)) + 1));
+
+    // Determine the width of each digit display area
+    int digitWidth = 12;
+
+    // Calculate the total width of the display area
+    int displayWidth = digitWidth * 8;
+
+    // Calculate the X-coordinate to center the number
+    int centerX = DisplayNumber::_x + (displayWidth - numDigits * digitWidth) / 2;
+
+    // Clear the display area with the background color
+    _tft.fillRect(centerX, DisplayNumber::_y, displayWidth, 24, TFT_BLACK);
+
+    // Print the new number
+    _tft.setCursor(centerX, DisplayNumber::_y);
+    if (numDigits <= 8) {
+      if (number < 0) {
+        _tft.print("-"); // Print the minus sign
+        _tft.printf("%07d", abs(number)); // Display the absolute value with leading zeros
+      } else {
+        _tft.printf("%08d", number); // Display with leading zeros
+      }
+    } else {
+      _tft.printf("%d", number); // Display without leading zeros
+    }
+
+    // Update the previousNumber for this display
+    DisplayNumber::_old_value = number;
+  }
+}

--- a/code/RemoteRx/src/tft/widgets/display_number/display_number.hpp
+++ b/code/RemoteRx/src/tft/widgets/display_number/display_number.hpp
@@ -1,0 +1,30 @@
+/**
+ * RC Transmitter – ESP32 / SX1280
+ * https://github.com/alx-uta/RC-Transmitter
+ * 
+ * Alex Uta
+ * microknot.dev
+ */
+
+#ifndef DISPLAY_NUMBER_HPP
+#define DISPLAY_NUMBER_HPP
+
+#include "../../../config/config.hpp"
+#include <TFT_eSPI.h>
+
+class DisplayNumber {
+ public:
+    DisplayNumber(Config& config, TFT_eSPI& tft, int x, int y);
+    int _x;
+    int _y;
+    int _old_value;
+    bool _widget_created = false;
+    void init();
+    void update(int number);
+
+ private:
+    Config& _config;
+    TFT_eSPI& _tft;
+};
+
+#endif  // DISPLAY_NUMBER_HPP

--- a/code/RemoteRx/src/tft/widgets/horizontal_slider/horizontal_slider.cpp
+++ b/code/RemoteRx/src/tft/widgets/horizontal_slider/horizontal_slider.cpp
@@ -1,0 +1,73 @@
+/**
+ * RC Transmitter – ESP32 / SX1280
+ * https://github.com/alx-uta/RC-Transmitter
+ * 
+ * Alex Uta
+ * microknot.dev
+ */
+
+#include "horizontal_slider.hpp"
+
+HorizontalSlider::HorizontalSlider(
+    Config & config, 
+    TFT_eSPI & tft,
+    int x,
+    int y,
+    int start_value,
+    int end_value,
+    int width
+)
+    :   _config(config),
+        _tft(tft) {
+            _x = x;
+            _y = y;
+            _start_value = start_value;
+            _end_value = end_value;
+            _width = width;
+        }
+
+void HorizontalSlider::init() {
+    HorizontalSlider::update(-1, true);
+}
+
+void HorizontalSlider::update(int position) {
+    HorizontalSlider::_update(position, false);
+}
+void HorizontalSlider::update(int position, bool init=false) {
+    HorizontalSlider::_update(position, init);
+}
+
+void HorizontalSlider::_update(int position, bool init=false) {
+
+    if(HorizontalSlider::_old_value!=position or not HorizontalSlider::_widget_created) {
+        HorizontalSlider::_widget_created = true;
+        HorizontalSlider::_old_value = position;
+
+        if(_y == 0) {
+            _y = _tft.height() - HorizontalSlider::_slider_height - 1;
+        }
+
+        // Clear the area to the left and right of the previous slider position
+        if (HorizontalSlider::_current_position != -1) {
+            int clearX = max(HorizontalSlider::_current_position, 0);
+            int clearWidth = min(HorizontalSlider::_slider_width + 2, _width - clearX);
+            _tft.fillRect(_x + clearX, _y, clearWidth, HorizontalSlider::_slider_height, _config.TFT_BACKGROUND);
+        }
+
+        // Calculate the slider position based on the provided value
+        int sliderX = map(position, 0, 255, 0, (_width - HorizontalSlider::_slider_width));
+
+        // Draw the slider track as vertical lines
+        for (int i = 0; i <= _width; i += HorizontalSlider::_line_track_distance) {
+            _tft.drawFastVLine(_x + i, _y, HorizontalSlider::_slider_height, TFT_DARKGREY);
+        }
+
+        // Draw the slider knob as a rectangle
+        if(!init) {
+            _tft.drawRect(_x + sliderX, _y, HorizontalSlider::_slider_width, HorizontalSlider::_slider_height, TFT_WHITE);
+        }
+
+        // Update the previous slider position
+        HorizontalSlider::_current_position = sliderX;
+    }
+}

--- a/code/RemoteRx/src/tft/widgets/horizontal_slider/horizontal_slider.hpp
+++ b/code/RemoteRx/src/tft/widgets/horizontal_slider/horizontal_slider.hpp
@@ -1,0 +1,51 @@
+/**
+ * RC Transmitter – ESP32 / SX1280
+ * https://github.com/alx-uta/RC-Transmitter
+ * 
+ * Alex Uta
+ * microknot.dev
+ */
+
+#ifndef HORIZONTAL_SLIDER_HPP
+#define HORIZONTAL_SLIDER_HPP
+
+#include "../../../config/config.hpp"
+#include <TFT_eSPI.h>
+
+class HorizontalSlider {
+ public:
+    HorizontalSlider(
+        Config& config,
+        TFT_eSPI& tft,
+        int x,
+        int y,
+        int start_value,
+        int end_value,
+        int width
+    );
+    int _x;
+    int _y;
+    int _default_value = 127;
+    int _start_value;
+    int _end_value;
+    int _width;
+
+    int _slider_width = 6;
+    int _slider_height = 6;
+    int _line_track_distance = 5;
+
+    int _old_value;
+    int _current_position = -1;
+    bool _widget_created = false;
+
+    void _update(int number, bool init);
+    void update(int number, bool init);
+    void update(int number);
+    void init();
+
+ private:
+    Config& _config;
+    TFT_eSPI& _tft;
+};
+
+#endif  // HORIZONTAL_SLIDER_HPP

--- a/code/RemoteRx/src/tft/widgets/rotary_encoder/rotary_encoder.cpp
+++ b/code/RemoteRx/src/tft/widgets/rotary_encoder/rotary_encoder.cpp
@@ -1,0 +1,70 @@
+/**
+ * RC Transmitter – ESP32 / SX1280
+ * https://github.com/alx-uta/RC-Transmitter
+ * 
+ * Alex Uta
+ * microknot.dev
+ */
+
+#include "rotary_encoder.hpp"
+
+RotaryEncoder::RotaryEncoder(
+    Config & config, 
+    TFT_eSPI & tft,
+    int x,
+    int y
+)
+    :   _config(config),
+        _tft(tft) {
+            _x = x;
+            _y = y;
+        }
+
+void RotaryEncoder::drawBigCircle() {
+    _tft.drawCircle(_x, _y, RotaryEncoder::big_circle_radius, _config.TFT_ENCODER_BORDER_COLOUR);
+}
+
+void RotaryEncoder::drawSmallCircle(int x, int y, int state) {
+    _border_colour = state ? _config.TFT_ENCODER_ACTIV_COLOUR : _config.TFT_ENCODER_BORDER_COLOUR;
+    _fill_colour = state ? _config.TFT_ENCODER_ACTIV_COLOUR : _config.TFT_ENCODER_BORDER_COLOUR;
+
+    _tft.drawCircle(x, y, RotaryEncoder::small_circle_radius, _border_colour);
+    _tft.fillCircle(x, y, RotaryEncoder::small_circle_radius - 2, _fill_colour);
+}
+
+void RotaryEncoder::drawSmallCircles(
+    int up,
+    int down,
+    int left,
+    int right,
+    int middle
+) {
+    drawSmallCircle(_x, _y - RotaryEncoder::big_circle_radius, up);
+    drawSmallCircle(_x, _y + RotaryEncoder::big_circle_radius, down);
+    drawSmallCircle(_x - RotaryEncoder::big_circle_radius, _y, left);
+    drawSmallCircle(_x + RotaryEncoder::big_circle_radius, _y, right);
+    drawSmallCircle(_x, _y, middle);
+}
+
+void RotaryEncoder::init(){
+    RotaryEncoder::drawBigCircle();
+    RotaryEncoder::update(
+        0, 0, 0, 0, 0
+    );
+}
+
+void RotaryEncoder::update(
+        int up,
+        int down,
+        int left,
+        int right,
+        int middle
+) {
+    RotaryEncoder::drawSmallCircles(
+        up,
+        down,
+        left,
+        right,
+        middle
+    );
+}

--- a/code/RemoteRx/src/tft/widgets/rotary_encoder/rotary_encoder.hpp
+++ b/code/RemoteRx/src/tft/widgets/rotary_encoder/rotary_encoder.hpp
@@ -1,0 +1,54 @@
+/**
+ * RC Transmitter – ESP32 / SX1280
+ * https://github.com/alx-uta/RC-Transmitter
+ * 
+ * Alex Uta
+ * microknot.dev
+ */
+
+#ifndef ROTARY_ENCODER_HPP
+#define ROTARY_ENCODER_HPP
+
+#include "../../../config/config.hpp"
+#include <TFT_eSPI.h>
+
+class RotaryEncoder {
+ public:
+    RotaryEncoder(
+        Config& config, 
+        TFT_eSPI& tft,
+        int x,
+        int y
+    );
+
+    int big_circle_radius = 30;
+    int small_circle_radius = 5;
+
+    void drawBigCircle();
+    void drawSmallCircle(int x, int y, int state);
+    void drawSmallCircles(
+        int up,
+        int down,
+        int left,
+        int right,
+        int middle
+    );
+    void update(
+        int up,
+        int down,
+        int left,
+        int right,
+        int middle
+    );
+    void init();
+
+ private:
+    Config& _config;
+    TFT_eSPI& _tft;
+    int _x;
+    int _y;
+    uint16_t _border_colour;
+    uint16_t _fill_colour;
+};
+
+#endif  // ROTARY_ENCODER_HPP

--- a/code/RemoteRx/src/tft/widgets/switch/switch.cpp
+++ b/code/RemoteRx/src/tft/widgets/switch/switch.cpp
@@ -1,0 +1,88 @@
+/**
+ * RC Transmitter – ESP32 / SX1280
+ * https://github.com/alx-uta/RC-Transmitter
+ * 
+ * Alex Uta
+ * microknot.dev
+ */
+
+#include "switch.hpp"
+
+Switch::Switch(
+    Config & config, 
+    TFT_eSPI & tft,
+    int x,
+    int y,
+    int index,
+    int width = 16,
+    int height = 20,
+    int spacing = 5,
+    bool display_off_box = false
+)
+    :   _config(config),
+        _tft(tft) {
+            _x = x;
+            _y = y;
+            _index = index;
+            _width = width;
+            _height = height;
+            _spacing = spacing;
+            _display_off_box = display_off_box;
+        }
+
+Switch::Switch(
+    Config & config, 
+    TFT_eSPI & tft,
+    int x,
+    int y,
+    int index
+)
+    :   _config(config),
+        _tft(tft) {
+            _x = x;
+            _y = y;
+            _index = index;
+            _width = 16;
+            _height = 20;
+            _spacing = 5;
+            _display_off_box = false;
+        }
+
+void Switch::init() {
+    Switch::update(0);
+}
+
+void Switch::update(int state) {
+    if(state == Switch::_old_value and !Switch::_widget_created) {
+        return;
+    }
+
+    Switch::_old_value = state;
+    Switch::_widget_created = true;
+
+    int x = _x + _index * (_width + _spacing);
+    int y = _y;
+    
+    // Define colors for the "on" and "off" states
+    uint16_t on_colour = _config.TFT_SWITCH_ON;
+    uint16_t off_colour = _config.TFT_SWITCH_OFF;
+    uint16_t disabled_colour = _config.TFT_SWITCH_DISABLED;
+    
+    // Determine the colors and borders based on the switch state
+    uint16_t top_box_colour = state ? on_colour : disabled_colour;
+    uint16_t top_box_border_colour = state ? on_colour : disabled_colour;
+    
+    uint16_t bottom_box_colour = state ? disabled_colour : off_colour;
+    uint16_t bottom_box_border_colour = state ? disabled_colour : off_colour;
+
+    // Draw the top box (represents "on" state)
+    _tft.drawRect(x, y, _width, _height / 2, top_box_border_colour);
+    _tft.fillRect(x + 2, y + 2, _width - 4, (_height / 2) - 4, top_box_colour);
+
+    if(Switch::_display_off_box){
+        // Draw the bottom box (represents "off" state)
+        y += _height / 2 + 2; // Add a small spacing
+        _tft.drawRect(_x, _y, _width, _height / 2, bottom_box_border_colour);
+        _tft.fillRect(_x + 2, _y + 2, _width - 4, (_height / 2) - 4, bottom_box_colour);
+    }
+}

--- a/code/RemoteRx/src/tft/widgets/switch/switch.hpp
+++ b/code/RemoteRx/src/tft/widgets/switch/switch.hpp
@@ -1,0 +1,55 @@
+/**
+ * RC Transmitter – ESP32 / SX1280
+ * https://github.com/alx-uta/RC-Transmitter
+ * 
+ * Alex Uta
+ * microknot.dev
+ */
+
+#ifndef SWITCH_HPP
+#define SWITCH_HPP
+
+#include "../../../config/config.hpp"
+#include <TFT_eSPI.h>
+
+class Switch {
+ public:
+    Switch(
+        Config& config, 
+        TFT_eSPI& tft,
+        int x,
+        int y,
+        int index
+    );
+    Switch(
+        Config& config, 
+        TFT_eSPI& tft,
+        int x,
+        int y,
+        int index,
+        int width,
+        int height,
+        int spacing,
+        bool display_off_box
+    );
+
+    void update(int state);
+    void init();
+
+    int _old_value = -1;
+    int _widget_created = false;
+    int display_off_box = false;
+
+ private:
+    Config& _config;
+    TFT_eSPI& _tft;
+    int _x;
+    int _y;
+    int _index;
+    int _width;
+    int _height;
+    int _spacing;
+    bool _display_off_box;
+};
+
+#endif  // SWITCH_HPP

--- a/code/RemoteRx/src/tft/widgets/vertical_slider/vertical_slider.cpp
+++ b/code/RemoteRx/src/tft/widgets/vertical_slider/vertical_slider.cpp
@@ -1,0 +1,105 @@
+/**
+ * RC Transmitter – ESP32 / SX1280
+ * https://github.com/alx-uta/RC-Transmitter
+ * 
+ * Alex Uta
+ * microknot.dev
+ */
+
+#include "vertical_slider.hpp"
+
+VerticalSlider::VerticalSlider(
+    Config & config, 
+    TFT_eSPI & tft,
+    int x,
+    int y,
+    int start_value,
+    int end_value,
+    int height,
+    int margin_top,
+    int track_width,
+    int track_spacing
+)
+    :   _config(config),
+        _tft(tft) {
+            _x = x;
+            _y = y;
+            _start_value = start_value;
+            _end_value = end_value;
+            _height = height;
+            _margin_top = margin_top;
+            _track_width = track_width;
+            _track_spacing = track_spacing;
+        }
+
+void VerticalSlider::init() {
+    VerticalSlider::update(-1, true);
+}
+
+void VerticalSlider::update(int position) {
+    VerticalSlider::_update(position, false);
+}
+void VerticalSlider::update(int position, bool init=false) {
+    VerticalSlider::_update(position, init);
+}
+
+void VerticalSlider::_update(int position, bool init = false) {
+    if(VerticalSlider::_old_value!=position or not VerticalSlider::_widget_created) {
+        VerticalSlider::_widget_created = true;
+        VerticalSlider::_old_value = position;
+
+        /**
+         * Clear the area above and below 
+         * the previous slider position
+         */
+        if (VerticalSlider::_current_position != -1) {
+            int clearY = max(
+                VerticalSlider::_current_position, _margin_top
+            );
+            int clearHeight = min(
+                _track_width,
+                _height - clearY
+            );
+            _tft.fillRect(
+                _x,
+                clearY,
+                _track_width,
+                clearHeight,
+                _config.TFT_BACKGROUND
+            );
+        }
+
+        // Define the slider track dimensions
+        int numSegments = (
+            _height - _margin_top
+        ) / _track_spacing + 1;
+
+        // Calculate the slider position based on the provided value
+        int sliderY = map(
+            position,
+            VerticalSlider::_start_value,
+            VerticalSlider::_end_value,
+            _margin_top,
+            (_height - VerticalSlider::_slider_height)
+        );
+
+        // Draw the slider track as horizontal lines
+        for (int i = 0; i < numSegments; i++) {
+            int segmentY = _margin_top + i * VerticalSlider::_line_track_distance;
+            _tft.drawFastHLine(_x, segmentY, _track_width, TFT_DARKGREY);
+        }
+
+        if(!init) {
+            _tft.drawRect(
+                _x,
+                sliderY,
+                _track_width,
+                _slider_height,
+                position == 0 and VerticalSlider::_start_value == 255 ? TFT_DARKGREY :  TFT_WHITE
+            );
+        }
+
+        // Update the previous slider position
+        VerticalSlider::_current_position = sliderY;
+    }
+}

--- a/code/RemoteRx/src/tft/widgets/vertical_slider/vertical_slider.hpp
+++ b/code/RemoteRx/src/tft/widgets/vertical_slider/vertical_slider.hpp
@@ -1,0 +1,56 @@
+/**
+ * RC Transmitter – ESP32 / SX1280
+ * https://github.com/alx-uta/RC-Transmitter
+ * 
+ * Alex Uta
+ * microknot.dev
+ */
+
+#ifndef VERTICAL_SLIDER_HPP
+#define VERTICAL_SLIDER_HPP
+
+#include "../../../config/config.hpp"
+#include <TFT_eSPI.h>
+
+class VerticalSlider {
+ public:
+    VerticalSlider(
+        Config& config,
+        TFT_eSPI& tft,
+        int x,
+        int y,
+        int start_value,
+        int end_value,
+        int height,
+        int margin_top,
+        int track_width,
+        int track_spacing
+    );
+    int _x;
+    int _y;
+    int _default_value = 127;
+    int _start_value;
+    int _end_value;
+    int _height;
+    int _margin_top;
+    int _track_width;
+    int _track_spacing;
+
+    int _slider_height = 6;
+    int _line_track_distance = 5;
+
+    int _old_value;
+    int _current_position = -1;
+    bool _widget_created = false;
+
+    void _update(int number, bool init);
+    void update(int number, bool init);
+    void update(int number);
+    void init();
+
+ private:
+    Config& _config;
+    TFT_eSPI& _tft;
+};
+
+#endif  // VERTICAL_SLIDER_HPP

--- a/code/RemoteTx/RemoteTx.ino
+++ b/code/RemoteTx/RemoteTx.ino
@@ -91,7 +91,7 @@ void setup() {
             "task_txReadData",
             100 * 1024,
             NULL,
-            0,
+            20,
             &task_txReadData,
             taskCore1
         );
@@ -101,7 +101,7 @@ void setup() {
             "task_txTransmitData",
             100 * 1024,
             NULL,
-            1,
+            19,
             &task_txTransmitData,
             taskCore2
         );

--- a/code/RemoteTx/example.user_config.hpp
+++ b/code/RemoteTx/example.user_config.hpp
@@ -32,6 +32,7 @@ uint8_t calibrationReadings     = 100;
 uint8_t pot_drift_value = 2;
 uint8_t pot_min = 0;
 int pot_max = 4093 // pot_max - pot_drift_value;
+uint8_t pot_out_min = 0;
 uint8_t pot_out_max = 255;
 
 /**
@@ -83,10 +84,6 @@ int
   \brief No shaping.
 */
 #define RADIOLIB_SHAPING_NONE                                   (0x00)
-/*!
-  \brief Gaussian shaping filter, BT = 0.3
-*/
-#define RADIOLIB_SHAPING_0_3                                    (0x01)
 
 /*!
   \brief Gaussian shaping filter, BT = 0.5
@@ -94,24 +91,20 @@ int
 #define RADIOLIB_SHAPING_0_5                                    (0x02)
 
 /*!
-  \brief Gaussian shaping filter, BT = 0.7
-*/
-#define RADIOLIB_SHAPING_0_7                                    (0x03)
-
-/*!
   \brief Gaussian shaping filter, BT = 1.0
 */
 #define RADIOLIB_SHAPING_1_0                                    (0x04)
 
 
-float   SX1280_FREQUENCY        = 2410.5;
-int     SX1280_BIT_RATE         = 800;
-int     SX1280_CODING_RATE      = 5;
-int     SX1280_OUTPUT_POWER     = 5; // -18 to 13 dBm
-int     SX1280_GAIN_CONTROL     = 5; // 1 - 13
-uint8_t SX1280_DATA_SHAPING     = RADIOLIB_SHAPING_0_5;
-uint8_t SX1280_SYNC_WORD[]      = {0x01, 0x23, 0x45, 0x67};
-int     SX1280_CRC_VALUE        = 1;
-int     SX1280_PREAMBLE_LENGTH  = 4;
+float   SX1280_FREQUENCY            = 2410;
+int     SX1280_FREQUENCY_DEVIATION  = 1500;
+int     SX1280_BIT_RATE             = 250;
+int     SX1280_CODING_RATE          = 5;
+int     SX1280_OUTPUT_POWER         = 8; // -18 to 13 dBm
+int     SX1280_GAIN_CONTROL         = 8; // 1 - 13
+uint8_t SX1280_DATA_SHAPING         = RADIOLIB_SHAPING_0_5;
+uint8_t SX1280_SYNC_WORD[]          = {0x01, 0x23, 0x45, 0x67};
+int     SX1280_CRC_VALUE            = 2;
+int     SX1280_PREAMBLE_LENGTH      = 4;
 
 #endif  // USER_CONFIG_HPP

--- a/code/RemoteTx/src/config/config.cpp
+++ b/code/RemoteTx/src/config/config.cpp
@@ -40,6 +40,7 @@ Config::Config (
     uint8_t pot_drift_value,
     uint8_t pot_min,
     int pot_max,
+    uint8_t pot_out_min,
     uint8_t pot_out_max
 ) {
     // Joystick General
@@ -73,5 +74,6 @@ Config::Config (
     Config::pot_drift_value = pot_drift_value;
     Config::pot_min = pot_min;
     Config::pot_max = pot_max;
+    Config::pot_out_min = pot_out_min;
     Config::pot_out_max = pot_out_max;
 }

--- a/code/RemoteTx/src/config/config.hpp
+++ b/code/RemoteTx/src/config/config.hpp
@@ -45,6 +45,7 @@ class Config {
             uint8_t pot_drift_value,
             uint8_t pot_min,
             int pot_max,
+            uint8_t pot_out_min,
             uint8_t pot_out_max
         );
         /**
@@ -159,6 +160,7 @@ class Config {
         uint8_t pot_drift_value;
         uint8_t pot_min;
         int pot_max;
+        uint8_t pot_out_min;
         uint8_t pot_out_max;
 
         // @todo: allow a public function to change the config for: 

--- a/code/RemoteTx/src/init.hpp
+++ b/code/RemoteTx/src/init.hpp
@@ -38,6 +38,7 @@ Config TX_CONFIG(
     pot_drift_value,
     pot_min,
     pot_max,
+    pot_out_min,
     pot_out_max
 );
 

--- a/code/RemoteTx/src/setup.hpp
+++ b/code/RemoteTx/src/setup.hpp
@@ -69,7 +69,7 @@ void setFlag(void) {
  * SX1280
  */
 void SX1280_setup() {
-    int state = radio.beginFLRC();
+    int state = radio.beginGFSK();
 
     array_size = sizeof(_TX._payload.byteArray);
     radio.implicitHeader(array_size);
@@ -91,6 +91,7 @@ void SX1280_setup() {
     state = radio.setGainControl(SX1280_GAIN_CONTROL);
 
     state = radio.setFrequency(SX1280_FREQUENCY);
+    state = radio.setFrequencyDeviation(SX1280_FREQUENCY_DEVIATION);
     state = radio.setBitRate(SX1280_BIT_RATE);
     state = radio.setCodingRate(SX1280_CODING_RATE);
     state = radio.setDataShaping(SX1280_DATA_SHAPING);

--- a/code/RemoteTx/src/tx/tx.cpp
+++ b/code/RemoteTx/src/tx/tx.cpp
@@ -34,6 +34,5 @@ Tx::Tx(
 void Tx::readData() {
     Tx::joysticks();
     Tx::potentiometers();
-    Tx::rotaryEncoders();
-    Tx::switches();
+    Tx::readMCP23S17();
 }

--- a/code/RemoteTx/src/tx/tx.hpp
+++ b/code/RemoteTx/src/tx/tx.hpp
@@ -30,8 +30,7 @@ public:
     void readData();
     void joysticks();
     void potentiometers();
-    void switches();
-    void rotaryEncoders();
+    void readMCP23S17();
     
     // Payload
     uint8_t* getByteArray();
@@ -42,11 +41,8 @@ public:
     void setRightJoystick(uint8_t x, uint8_t y);
 
     void setPotentiometers(uint8_t p1, uint8_t p2, uint8_t p3, uint8_t p4, uint8_t p5, uint8_t p6);
-    void setPotentiometerSwitches(uint8_t p1s, uint8_t p2s, uint8_t p3s, uint8_t p4s, uint8_t p5s, uint8_t p6s);
-    void setSwitches(uint8_t s1, uint8_t s2, uint8_t s3, uint8_t s4, uint8_t s5);
-    void setAnoRotaryEncoderLeft(uint8_t up, uint8_t down, uint8_t left, uint8_t right, uint8_t center);
+    void setSwitchesPushButtons(uint16_t pin_state_encoders, uint16_t pin_state_switches);
     void setAnoRotaryEncoderLeftPosition(uint8_t low, uint8_t mid_low, uint8_t mid_high, uint8_t high);
-    void setAnoRotaryEncoderRight(uint8_t up, uint8_t down, uint8_t left, uint8_t right, uint8_t center);
     void setAnoRotaryEncoderRightPosition(uint8_t low, uint8_t mid_low, uint8_t mid_high, uint8_t high);
     
     int leftAnoRotaryEncoderPosition = 0;
@@ -54,8 +50,13 @@ public:
     int getAnoRotaryEncoderPosition(uint8_t high, uint8_t mid_high, uint8_t mid_low, uint8_t low);
     int getLeftAnoRotaryEncoderPosition();
     int getRightAnoRotaryEncoderPosition();
+    uint16_t encodeSwitchStatusesToByte(bool switchStatuses[], int numSwitches);
+    void decodeByteToSwitchStatuses(uint16_t encodedByte, bool switchStatuses[], int numSwitches);
 
     typedef struct package {
+        // Set the sender identifier number
+        uint8_t sender; // left-right
+
         // Left Joystick
         uint8_t j1x; // left-right
         uint8_t j1y; // up-down
@@ -72,51 +73,25 @@ public:
         uint8_t p5;
         uint8_t p6;
 
-        // Potentiometers - Switches
-        uint8_t p1s;
-        uint8_t p2s;
-        uint8_t p3s;
-        uint8_t p4s;
-        uint8_t p5s;
-        uint8_t p6s;
-        
-        // Switches
-        uint8_t s1;
-        uint8_t s2;
-        uint8_t s3;
-        uint8_t s4;
-        uint8_t s5;
-
-        // Ano Rotary Encoder - Left
-        uint8_t re1_up;
-        uint8_t re1_down;
-        uint8_t re1_left;
-        uint8_t re1_right;
-        uint8_t re1_center;
-
         // Split re1_pos into individual bytes
-        uint8_t re1_pos_low;
-        uint8_t re1_pos_mid_low;
-        uint8_t re1_pos_mid_high;
         uint8_t re1_pos_high;
-
-        // Ano Rotary Encoder - Right
-        uint8_t re2_up;
-        uint8_t re2_down;
-        uint8_t re2_left;
-        uint8_t re2_right;
-        uint8_t re2_center;
+        uint8_t re1_pos_mid_high;
+        uint8_t re1_pos_mid_low;
+        uint8_t re1_pos_low;
 
         // Split re2_pos into individual bytes
-        uint8_t re2_pos_low;
-        uint8_t re2_pos_mid_low;
-        uint8_t re2_pos_mid_high;
         uint8_t re2_pos_high;
+        uint8_t re2_pos_mid_high;
+        uint8_t re2_pos_mid_low;
+        uint8_t re2_pos_low;
+
+        uint8_t switches_state_1;
+        uint8_t switches_state_2;
     };
 
     typedef union btPacket_t {
         package structure;
-        uint8_t byteArray[39];
+        uint8_t byteArray[21];
     };
 
     btPacket_t _payload;
@@ -133,8 +108,6 @@ private:
         int out_min,
         int out_max
     );
-    int encoderDirection(unsigned char direction);
-    int encoderPosition(int current_position, int direction);
 
     MCP3208& _joystick;
     MCP3208& _potentiometer;

--- a/code/RemoteTx/src/tx/tx_data.cpp
+++ b/code/RemoteTx/src/tx/tx_data.cpp
@@ -38,7 +38,9 @@ void Tx::joysticks() {
 
     // Joysticks Values
     int16_t readings[joysticks_num_channels];
-    _joystick.analogReadMultiple(joysticks_channels, joysticks_num_channels, readings);
+    _joystick.analogReadMultiple(
+        joysticks_channels, joysticks_num_channels, readings
+    );
 
     joystick_x1 = readings[_config.LEFT_JOYSTICK_X];
     joystick_y1 = readings[_config.LEFT_JOYSTICK_Y];
@@ -89,12 +91,32 @@ void Tx::joysticks() {
      * Set the payload accounting for the drift value
      */
     // Left Joystick
-    x1 = Tx::applyJoystickThreshold(joystick_x1, _config.left_joystick_middle_value_x, _config.left_joystick_drift_value_x, joystick_x1_map);
-    y1 = Tx::applyJoystickThreshold(joystick_y1, _config.left_joystick_middle_value_y, _config.left_joystick_drift_value_y, joystick_y1_map);
+    x1 = Tx::applyJoystickThreshold(
+        joystick_x1,
+        _config.left_joystick_middle_value_x,
+        _config.left_joystick_drift_value_x,
+        joystick_x1_map
+    );
+    y1 = Tx::applyJoystickThreshold(
+        joystick_y1,
+        _config.left_joystick_middle_value_y,
+        _config.left_joystick_drift_value_y,
+        joystick_y1_map
+    );
 
     // Right Joystick
-    x2 = Tx::applyJoystickThreshold(joystick_x2, _config.right_joystick_middle_value_x, _config.right_joystick_drift_value_x, joystick_x2_map);
-    y2 = Tx::applyJoystickThreshold(joystick_y2, _config.right_joystick_middle_value_y, _config.right_joystick_drift_value_y, joystick_y2_map);
+    x2 = Tx::applyJoystickThreshold(
+        joystick_x2,
+        _config.right_joystick_middle_value_x,
+        _config.right_joystick_drift_value_x,
+        joystick_x2_map
+    );
+    y2 = Tx::applyJoystickThreshold(
+        joystick_y2,
+        _config.right_joystick_middle_value_y,
+        _config.right_joystick_drift_value_y,
+        joystick_y2_map
+    );
 
     Tx::setLeftJoystick(x1, y1);
     Tx::setRightJoystick(x2, y2);
@@ -167,18 +189,18 @@ void Tx::potentiometers() {
 /**
  * Read the data for the rotary encoders
  */
-void Tx::rotaryEncoders() {
-    uint16_t pinState = _rotaryRead.read16();
+void Tx::readMCP23S17() {
+    uint16_t pin_state_encoders = _rotaryRead.read16();
 
     // Get the encoder position
     Tx::leftAnoRotaryEncoderPosition -= _leftRotary.encoderDirection(
-        (pinState & (1 << _config.rotary_encoder_1_enc_b)) != 0,
-        (pinState & (1 << _config.rotary_encoder_1_enc_a)) != 0
+        (pin_state_encoders & (1 << _config.rotary_encoder_1_enc_b)) != 0,
+        (pin_state_encoders & (1 << _config.rotary_encoder_1_enc_a)) != 0
     );
 
     Tx::rightAnoRotaryEncoderPosition -= _rightRotary.encoderDirection(
-        (pinState & (1 << _config.rotary_encoder_2_enc_b)) != 0,
-        (pinState & (1 << _config.rotary_encoder_2_enc_a)) != 0
+        (pin_state_encoders & (1 << _config.rotary_encoder_2_enc_b)) != 0,
+        (pin_state_encoders & (1 << _config.rotary_encoder_2_enc_a)) != 0
     );
 
     // Update the encoder position
@@ -196,51 +218,10 @@ void Tx::rotaryEncoders() {
         (uint8_t)(Tx::rightAnoRotaryEncoderPosition >> 24)
     );
 
-    // Update the push buttons
-    Tx::setAnoRotaryEncoderLeft(
-        (pinState & (1 << _config.rotary_encoder_1_up)) != 0,
-        (pinState & (1 << _config.rotary_encoder_1_down)) != 0,
-        (pinState & (1 << _config.rotary_encoder_1_left)) != 0,
-        (pinState & (1 << _config.rotary_encoder_1_right)) != 0,
-        (pinState & (1 << _config.rotary_encoder_1_center)) != 0
-    );
-
-    Tx::setAnoRotaryEncoderRight(
-        (pinState & (1 << _config.rotary_encoder_2_up)) != 0,
-        (pinState & (1 << _config.rotary_encoder_2_down)) != 0,
-        (pinState & (1 << _config.rotary_encoder_2_left)) != 0,
-        (pinState & (1 << _config.rotary_encoder_2_right)) != 0,
-        (pinState & (1 << _config.rotary_encoder_2_center)) != 0
-    );
-}
-
-
-/**
- * Read the data for the switches
- */
-void Tx::switches() {
-
-    uint16_t pinState = _switches.read16();
-    /**
-     * Potentiometer Switch Button
-     */
-    Tx::setPotentiometerSwitches(
-        (pinState & (1 << _config.button_switch_pot_1)) != 0,
-        (pinState & (1 << _config.button_switch_pot_2)) != 0,
-        (pinState & (1 << _config.button_switch_pot_3)) != 0,
-        (pinState & (1 << _config.button_switch_pot_4)) != 0,
-        (pinState & (1 << _config.button_switch_pot_5)) != 0,
-        (pinState & (1 << _config.button_switch_pot_6)) != 0
-    );
-
-    /**
-     * Switch Button
-     */
-    Tx::setSwitches(
-        (pinState & (1 << _config.button_switch_1)) != 0,
-        (pinState & (1 << _config.button_switch_2)) != 0,
-        (pinState & (1 << _config.button_switch_3)) != 0,
-        (pinState & (1 << _config.button_switch_4)) != 0,
-        (pinState & (1 << _config.button_switch_5)) != 0
+    // pin_state_encoders
+    uint16_t pin_state_switches = _switches.read16();
+    Tx::setSwitchesPushButtons(
+        pin_state_encoders,
+        pin_state_switches
     );
 }

--- a/code/RemoteTx/src/tx/tx_utils.cpp
+++ b/code/RemoteTx/src/tx/tx_utils.cpp
@@ -31,3 +31,19 @@ int Tx::joystickMap(
     return (output > out_max) ? out_max : output;
   }
 }
+
+uint16_t Tx::encodeSwitchStatusesToByte(bool switchStatuses[], int numSwitches) {
+    uint16_t encodedByte = 0;
+
+    for (int i = 0; i < numSwitches; i++) {
+        encodedByte |= (switchStatuses[i] << i);
+    }
+
+    return encodedByte;
+}
+
+void Tx::decodeByteToSwitchStatuses(uint16_t encodedByte, bool switchStatuses[], int numSwitches) {
+  for (int i = 0; i < numSwitches; i++) {
+    switchStatuses[i] = (encodedByte >> i) & 0x01;
+  }
+}


### PR DESCRIPTION
Remote RX / TFT screen
- beta 1.0

Remote TX
- removed the potentiometer switches from the payload
- included a new byte to identify the sender
- use a single byte instead of 15 for the push buttons and switches