### PR TITLE
Dynamic allocation for the channels and only sending data when needed.

### DIFF
--- a/code/RemoteRx/example.user_config.hpp
+++ b/code/RemoteRx/example.user_config.hpp
@@ -17,7 +17,7 @@
 /**
  * Battery
  */
-int BATTERY_MIN = 1900; // 3.5v
+int BATTERY_MIN = 1925; // 3.5v
 int BATTERY_MAX = 2315; // 4.2v
 
 /**

--- a/code/RemoteRx/src/init.hpp
+++ b/code/RemoteRx/src/init.hpp
@@ -183,7 +183,8 @@ Rx _RX(
     _S5
 );
 
-const int _payload_size = 17;
+// Maximum payload size
+const int _payload_size = 18;
 uint8_t _payload[_payload_size];
 
 /**

--- a/code/RemoteRx/src/rx/rx.cpp
+++ b/code/RemoteRx/src/rx/rx.cpp
@@ -93,13 +93,130 @@ Rx::Rx(
 void Rx::setData(
     uint8_t* _payload
 ) {
-    if(_payload[0] == 1 and _config.CURRENT_FREQUENCY==_config.SX1280_FREQUENCY) {
+    // Get the config from the first two bytes
+    uint16_t config_combined_byte = Rx::combineBytes(
+        _payload[0],
+        _payload[1]
+    );
+
+    // Decode the uint16_t back into config and channels
+    bool decoded_config[16];
+    Rx::decodeByteToStatuses(config_combined_byte, decoded_config, 16);
+
+    for (int i = 3; i < 16; i++) {
+        Rx::payload_config[i] = decoded_config[i];
+    }
+
+    if(Rx::payload_config[0] == 0 and _config.CURRENT_FREQUENCY==_config.SX1280_FREQUENCY) {
         Rx::setTXpayload(_payload);
     }
 }
 
 void Rx::setTXpayload(uint8_t* _payload) {
-    memcpy(Rx::_payload.byteArray, _payload, sizeof(Rx::_payload.byteArray));
+    uint8_t current_position = 2;
+
+    for (int i = 3; i < 16; i++) {
+        uint8_t channel = i - 2;
+        if (this->payload_config[i]) {
+            uint8_t required_bytes = this->channels[channel-1].required_bytes;
+            uint8_t first_byte = _payload[current_position++];
+            uint8_t second_byte = (required_bytes == 2) ? _payload[current_position++] : 0;
+            Rx::setChannel(channel, first_byte, second_byte);
+        } else {
+            uint8_t default_value = this->channels[channel-1].default_value;
+            Rx::setChannel(channel, default_value, 0);
+        }
+    }
+}
+
+void Rx::setChannel(uint8_t channel, uint8_t first_byte, uint8_t second_byte) {
+    switch (channel) {
+        case 1:
+            setCh1(first_byte);
+            break;
+        case 2:
+            setCh2(first_byte);
+            break;
+        case 3:
+            setCh3(first_byte);
+            break;
+        case 4:
+            setCh4(first_byte);
+            break;
+        case 5:
+            setCh5(first_byte, second_byte);
+            break;
+        case 6:
+            setCh6(first_byte, second_byte);
+            break;
+        case 7:
+            setCh7(first_byte, second_byte);
+            break;
+        case 8:
+            setCh8(first_byte);
+            break;
+        case 9:
+            setCh9(first_byte);
+            break;
+        case 10:
+            setCh10(first_byte);
+            break;
+        case 11:
+            setCh11(first_byte);
+            break;
+        case 12:
+            setCh12(first_byte);
+            break;
+        case 13:
+            setCh13(first_byte);
+            break;
+        default:
+            // pass
+            break;
+    }
+}
+
+void Rx::setCh1(uint8_t byte_1) {
+    Rx::_payload.data.j1x = byte_1;
+}
+void Rx::setCh2(uint8_t byte_1) {
+    Rx::_payload.data.j1y = byte_1;
+}
+void Rx::setCh3(uint8_t byte_1) {
+    Rx::_payload.data.j2x = byte_1;
+}
+void Rx::setCh4(uint8_t byte_1) {
+    Rx::_payload.data.j2y = byte_1;
+}
+void Rx::setCh5(uint8_t byte_1, uint8_t byte_2) {
+    Rx::_payload.data.switches_state_1 = byte_1;
+    Rx::_payload.data.switches_state_2 = byte_2;
+}
+void Rx::setCh6(uint8_t byte_1, uint8_t byte_2) {
+    Rx::_payload.data.re1_byte_1 = byte_1;
+    Rx::_payload.data.re1_byte_2 = byte_2;
+}
+void Rx::setCh7(uint8_t byte_1, uint8_t byte_2) {
+    Rx::_payload.data.re2_byte_1 = byte_1;
+    Rx::_payload.data.re2_byte_2 = byte_2;
+}
+void Rx::setCh8(uint8_t byte_1) {
+    Rx::_payload.data.p1 = byte_1;
+}
+void Rx::setCh9(uint8_t byte_1) {
+    Rx::_payload.data.p2 = byte_1;
+}
+void Rx::setCh10(uint8_t byte_1) {
+    Rx::_payload.data.p3 = byte_1;
+}
+void Rx::setCh11(uint8_t byte_1) {
+    Rx::_payload.data.p4 = byte_1;
+}
+void Rx::setCh12(uint8_t byte_1) {
+    Rx::_payload.data.p5 = byte_1;
+}
+void Rx::setCh13(uint8_t byte_1) {
+    Rx::_payload.data.p6 = byte_1;
 }
 
 void Rx::updateTftRemoteTX() {
@@ -108,60 +225,60 @@ void Rx::updateTftRemoteTX() {
      */
     _LEFT_JOYSTICK_X.update(
         constrain(
-            Rx::_payload.structure.j1x, _config.joystick_min, _config.joystick_max
+            Rx::_payload.data.j1x, _config.joystick_min, _config.joystick_max
         )
     );
     _LEFT_JOYSTICK_Y.update(
         constrain(
-            Rx::_payload.structure.j1y, _config.joystick_min, _config.joystick_max
+            Rx::_payload.data.j1y, _config.joystick_min, _config.joystick_max
         )
     );
         
     _RIGHT_JOYSTICK_X.update(
         constrain(
-            Rx::_payload.structure.j2x, _config.joystick_min, _config.joystick_max
+            Rx::_payload.data.j2x, _config.joystick_min, _config.joystick_max
         )
     );
     _RIGHT_JOYSTICK_Y.update(
         constrain(
-            Rx::_payload.structure.j2y, _config.joystick_min, _config.joystick_max
+            Rx::_payload.data.j2y, _config.joystick_min, _config.joystick_max
         )
     );
 
     /**
      * Potentiometers
      */
-    _SLIDER_POT_1.update(constrain(Rx::_payload.structure.p1,_config.pot_min,_config.pot_max));
-    _SLIDER_POT_2.update(constrain(Rx::_payload.structure.p2,_config.pot_min,_config.pot_max));
-    _SLIDER_POT_3.update(constrain(Rx::_payload.structure.p3,_config.pot_min,_config.pot_max));
-    _SLIDER_POT_4.update(constrain(Rx::_payload.structure.p4,_config.pot_min,_config.pot_max));
-    _SLIDER_POT_5.update(constrain(Rx::_payload.structure.p5,_config.pot_min,_config.pot_max));
-    _SLIDER_POT_6.update(constrain(Rx::_payload.structure.p6,_config.pot_min,_config.pot_max));
+    _SLIDER_POT_1.update(constrain(Rx::_payload.data.p1,_config.pot_min,_config.pot_max));
+    _SLIDER_POT_2.update(constrain(Rx::_payload.data.p2,_config.pot_min,_config.pot_max));
+    _SLIDER_POT_3.update(constrain(Rx::_payload.data.p3,_config.pot_min,_config.pot_max));
+    _SLIDER_POT_4.update(constrain(Rx::_payload.data.p4,_config.pot_min,_config.pot_max));
+    _SLIDER_POT_5.update(constrain(Rx::_payload.data.p5,_config.pot_min,_config.pot_max));
+    _SLIDER_POT_6.update(constrain(Rx::_payload.data.p6,_config.pot_min,_config.pot_max));
 
     /**
      * Rotary Encoders
      */
     _DISPLAY_POSITION_LEFT.update(
         Rx::getAnoRotaryEncoderPosition(
-            Rx::_payload.structure.re1_byte_1,
-            Rx::_payload.structure.re1_byte_2
+            Rx::_payload.data.re1_byte_1,
+            Rx::_payload.data.re1_byte_2
         )
     );
 
     _DISPLAY_POSITION_RIGHT.update(
         Rx::getAnoRotaryEncoderPosition(
-            Rx::_payload.structure.re2_byte_1,
-            Rx::_payload.structure.re2_byte_2
+            Rx::_payload.data.re2_byte_1,
+            Rx::_payload.data.re2_byte_2
         )
     );
 
     uint16_t combined_byte = Rx::combineBytes(
-        Rx::_payload.structure.switches_state_1, Rx::_payload.structure.switches_state_2
+        Rx::_payload.data.switches_state_1, Rx::_payload.data.switches_state_2
     );
 
     // Decode the uint16_t back into switch statuses
     bool decoded_switch_statuses[15];
-    Rx::decodeByteToSwitchStatuses(combined_byte, decoded_switch_statuses, 15);
+    Rx::decodeByteToStatuses(combined_byte, decoded_switch_statuses, 15);
 
     /**
      * Switches

--- a/code/RemoteRx/src/rx/rx.hpp
+++ b/code/RemoteRx/src/rx/rx.hpp
@@ -64,11 +64,28 @@ class Rx {
     void setData(uint8_t* _payload);
     void setTXpayload(uint8_t* _payload);
 
+    void setChannel(uint8_t channel, uint8_t first_byte, uint8_t second_byte);
+
+    // Set each channel
+    void setCh1(uint8_t byte_1);
+    void setCh2(uint8_t byte_1);
+    void setCh3(uint8_t byte_1);
+    void setCh4(uint8_t byte_1);
+    void setCh5(uint8_t byte_1, uint8_t byte_2);
+    void setCh6(uint8_t byte_1, uint8_t byte_2);
+    void setCh7(uint8_t byte_1, uint8_t byte_2);
+    void setCh8(uint8_t byte_1);
+    void setCh9(uint8_t byte_1);
+    void setCh10(uint8_t byte_1);
+    void setCh11(uint8_t byte_1);
+    void setCh12(uint8_t byte_1);
+    void setCh13(uint8_t byte_1);
+
     void updateTftRemoteTX();
 
     // Utils
     int16_t getAnoRotaryEncoderPosition(uint8_t byte_1, uint8_t byte_2);
-    void decodeByteToSwitchStatuses(uint16_t encodedByte, bool switchStatuses[], int numSwitches);
+    void decodeByteToStatuses(uint16_t encodedByte, bool statuses[], int num);
     uint16_t combineBytes(uint8_t byte1, uint8_t byte2);
 
     float valRound(float val);
@@ -77,8 +94,9 @@ class Rx {
 
     // Payload
     typedef struct package {
-        // Set the sender identifier number
-        uint8_t sender; // left-right
+        // Config
+        uint8_t config_first_byte;
+        uint8_t config_second_byte;
 
         // Left Joystick
         uint8_t j1x; // left-right
@@ -109,12 +127,72 @@ class Rx {
     };
 
     typedef union btPacket_t {
-        package structure;
-        uint8_t byteArray[17];
+        package data;
+        uint8_t byteArray[18];
     };
     package payload;
-
     btPacket_t _payload;
+
+    /**
+     * TX Payload Config
+     * TX0 : Remote TX
+     * TX1 : Sensors 1
+     * TX2 : Sensors 2
+     * 
+     * CH1  : j1y - Left Joystick Up/Down
+     * CH2  : j1x - Left Joystick Left/Right
+     * CH3  : j2y - Right Joystick Up/Down
+     * CH4  : j2x - Right Joystick Left/Right
+     * CH5  : switches_state_1 + switches_state_2
+     * CH6  : re1_byte_1 + re1_byte_2
+     * CH7  : re2_byte_1 + re2_byte_2
+     * CH8  : p1
+     * CH9  : p2
+     * CH10 : p3
+     * CH11 : p4
+     * CH12 : p5
+     * CH13 : p6
+     */
+    bool payload_config[16] = {
+        0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+    };
+
+    typedef struct Channel {
+        uint8_t required_bytes;
+        uint8_t default_value;
+    };
+
+    /**
+     * CH1  : j1y - Left Joystick Up/Down
+     * CH2  : j1x - Left Joystick Left/Right
+     * CH3  : j2y - Right Joystick Up/Down
+     * CH4  : j2x - Right Joystick Left/Right
+     * CH5  : switches_state_1 + switches_state_2
+     * CH6  : re1_byte_1 + re1_byte_2
+     * CH7  : re2_byte_1 + re2_byte_2
+     * CH8  : p1
+     * CH9  : p2
+     * CH10 : p3
+     * CH11 : p4
+     * CH12 : p5
+     * CH13 : p6
+     */
+    Channel channels[13] = {
+        {1, 127},
+        {1, 127},
+        {1, 127},
+        {1, 127},
+        {2, 0},
+        {2, 0},
+        {2, 0},
+        {1, 0},
+        {1, 0},
+        {1, 0},
+        {1, 0},
+        {1, 0},
+        {1, 0}
+    };
 
  private:
     Config& _config;

--- a/code/RemoteRx/src/rx/rx_utils.cpp
+++ b/code/RemoteRx/src/rx/rx_utils.cpp
@@ -21,9 +21,9 @@ int16_t Rx::getAnoRotaryEncoderPosition(
     return 0;
 }
 
-void Rx::decodeByteToSwitchStatuses(uint16_t encodedByte, bool switchStatuses[], int numSwitches) {
-  for (int i = 0; i < numSwitches; i++) {
-    switchStatuses[i] = (encodedByte >> i) & 0x01;
+void Rx::decodeByteToStatuses(uint16_t encodedByte, bool statuses[], int num) {
+  for (int i = 0; i < num; i++) {
+    statuses[i] = (encodedByte >> i) & 0x01;
   }
 }
 

--- a/code/RemoteRx/src/setup.hpp
+++ b/code/RemoteRx/src/setup.hpp
@@ -131,15 +131,30 @@ void receiveData() {
         #endif
 
         #if ENABLE_DEBUG
-            // Debug the payload
-            for(int i=0; i < _payload_size; i++)
-            {
-                Serial.print(_payload[i]);
-                if(i < _payload_size - 1) {
-                    Serial.print(" : "); 
+            uint8_t current_position = 2;
+            bool data_received = false;
+            for (int i = 3; i < 16; i++) {
+                uint8_t channel = i - 2;
+                if (_RX.payload_config[i]) {
+                    uint8_t required_bytes = _RX.channels[channel-1].required_bytes;
+                    uint8_t first_byte = _payload[current_position++];
+                    uint8_t second_byte = (required_bytes == 2) ? _payload[current_position++] : 0;
+                    data_received = true;
+
+                    Serial.print("ch#");
+                    Serial.print(channel);
+                    Serial.print(":");
+                    Serial.print(first_byte);
+                    if(second_byte) {
+                        Serial.print(" ");
+                        Serial.print(second_byte);
+                    }
+                    Serial.print(" ");
                 }
             }
-            Serial.println();
+            if(data_received) {
+                Serial.println("");
+            }
         #endif
     #endif
       radio.startReceive();

--- a/code/RemoteTx/RemoteTx.ino
+++ b/code/RemoteTx/RemoteTx.ino
@@ -63,12 +63,6 @@ void setup() {
     #endif
 
     /**
-     * Set the default values and 
-     * create the structure for the payload
-     */
-    _TX.defaultValues();
-
-    /**
      * SX1280 setup
      */
     SX1280_setup();

--- a/code/RemoteTx/src/init.hpp
+++ b/code/RemoteTx/src/init.hpp
@@ -116,4 +116,3 @@ Tx _TX(
 );
 
 uint8_t* _payload;
-int array_size;

--- a/code/RemoteTx/src/tx/tx_payload.cpp
+++ b/code/RemoteTx/src/tx/tx_payload.cpp
@@ -8,56 +8,46 @@
 
 #include "tx.hpp"
 
-void Tx::defaultValues() {
-    // Identifier
-    this->_payload.structure.sender = 1;
-
-    // Joystick - Left
-    this->_payload.structure.j1x = joystick_default_value; // left-right
-    this->_payload.structure.j1y = joystick_default_value; // up-down
-
-    // Joystick - Right
-    this->_payload.structure.j2x = joystick_default_value; // left-right
-    this->_payload.structure.j2y = joystick_default_value; // up-down
-
-    // Potentiometers
-    this->_payload.structure.p1 = 0;
-    this->_payload.structure.p2 = 0;
-    this->_payload.structure.p3 = 0;
-    this->_payload.structure.p4 = 0;
-    this->_payload.structure.p5 = 0;
-    this->_payload.structure.p6 = 0;
-
-    // Ano Rotary Encoder - Left
-    this->_payload.structure.re1_byte_1 = 0;
-    this->_payload.structure.re1_byte_2 = 0;
-
-    // Ano Rotary Encoder - Right
-    this->_payload.structure.re2_byte_1 = 0;
-    this->_payload.structure.re2_byte_2 = 0;
-
-    this->_payload.structure.switches_state_1 = 0;
-    this->_payload.structure.switches_state_2 = 0;
-}
-
-
 void Tx::setLeftJoystick(uint8_t x, uint8_t y) {
-    this->_payload.structure.j1x = x;
-    this->_payload.structure.j1y = y;
+    // Enable or disable this channel
+    payload_config[3] = (x == joystick_default_value) ? 0 : 1;
+    if (payload_config[3]) {
+        this->channels[0].first_byte = x;
+    }
+
+    // Enable or disable this channel
+    payload_config[4] = (y == joystick_default_value) ? 0 : 1;
+    if (payload_config[4]) {
+        this->channels[1].first_byte = y;
+    }
 }
 
 void Tx::setRightJoystick(uint8_t x, uint8_t y) {
-    this->_payload.structure.j2x = x;
-    this->_payload.structure.j2y = y;
+    // Enable or disable this channel
+    payload_config[5] = (x == joystick_default_value) ? 0 : 1;
+    if(payload_config[5]) {
+        this->channels[2].first_byte = x;
+    }
+
+    // Enable or disable this channel
+    payload_config[6] = (y == joystick_default_value) ? 0 : 1;
+    if(payload_config[6]) {
+        this->channels[3].first_byte = y;
+    }
 }
 
 void Tx::setPotentiometers(uint8_t p1, uint8_t p2, uint8_t p3, uint8_t p4, uint8_t p5, uint8_t p6) {
-    this->_payload.structure.p1 = p1;
-    this->_payload.structure.p2 = p2;
-    this->_payload.structure.p3 = p3;
-    this->_payload.structure.p4 = p4;
-    this->_payload.structure.p5 = p5;
-    this->_payload.structure.p6 = p6;
+    uint8_t p_values[] = {p1, p2, p3, p4, p5, p6};
+    uint8_t payload_config_offset = 10;
+
+    for (int i = 0; i < 6; i++) {
+        // Update the payload_config and channels
+        payload_config[payload_config_offset + i] = (p_values[i] == 0) ? 0 : 1;
+
+        if (payload_config[payload_config_offset + i]) {
+            this->channels[7 + i].first_byte = p_values[i];
+        }
+    }
 }
 
 void Tx::setSwitchesPushButtons(uint16_t pin_state_encoders, uint16_t pin_state_switches) {
@@ -85,21 +75,35 @@ void Tx::setSwitchesPushButtons(uint16_t pin_state_encoders, uint16_t pin_state_
     };
 
     // Encode switch statuses into two bytes
-    uint16_t switches_state = Tx::encodeSwitchStatusesToByte(switchStatuses, 15);
+    this->switches_state = Tx::encodeStatusToByte(switchStatuses, 15);
 
-    // Extract the lower and upper bytes
-    this->_payload.structure.switches_state_1 = (switches_state & 0xFF);
-    this->_payload.structure.switches_state_2 = ((switches_state >> 8) & 0xFF);
+    // Enable or disable this channel
+    payload_config[7] = (0 == this->switches_state) ? 0 : 1;
+    if(payload_config[7]) {
+        // Update the channel for the switches
+        // Extract the lower and upper bytes
+        this->channels[4].first_byte = (this->switches_state & 0xFF);
+        this->channels[4].second_byte = ((this->switches_state >> 8) & 0xFF);
+    }
+
 }
 
 void Tx::setAnoRotaryEncoderLeftPosition(uint8_t byte_1, uint8_t byte_2) {
-    this->_payload.structure.re1_byte_1 = byte_1;
-    this->_payload.structure.re1_byte_2 = byte_2;
+    // Enable or disable this channel
+    payload_config[8] = ((0 == byte_1) and (0 == byte_2)) ? 0 : 1;
+    if(payload_config[8]) {
+        this->channels[5].first_byte = byte_1;
+        this->channels[5].second_byte = byte_2;
+    }
 }
 
 void Tx::setAnoRotaryEncoderRightPosition(uint8_t byte_1, uint8_t byte_2) {
-    this->_payload.structure.re2_byte_1 = byte_1;
-    this->_payload.structure.re2_byte_2 = byte_2;
+    // Enable or disable this channel
+    payload_config[9] = ((0 == byte_1) and (0 == byte_2)) ? 0 : 1;
+    if(payload_config[9]) {
+        this->channels[6].first_byte = byte_1;
+        this->channels[6].second_byte = byte_2;
+    }
 }
 
 int16_t Tx::getAnoRotaryEncoderPosition(
@@ -109,20 +113,44 @@ int16_t Tx::getAnoRotaryEncoderPosition(
     return (int16_t)((byte_1 << 8) | byte_2);
 }
 
-int16_t Tx::getLeftAnoRotaryEncoderPosition() {
-    return Tx::getAnoRotaryEncoderPosition(
-        this->_payload.structure.re1_byte_1,
-        this->_payload.structure.re1_byte_2
-    );
+int Tx::getPayloadSize() {
+    this->payload_size = 2;
+    for (int i = 3; i < 16; i++) {
+        if (payload_config[i]) {
+            this->increasePayloadSize(this->channels[i - 3].required_bytes);
+        }
+    }
+    return this->payload_size;
 }
 
-int16_t Tx::getRightAnoRotaryEncoderPosition() {
-    return Tx::getAnoRotaryEncoderPosition(
-        this->_payload.structure.re2_byte_1,
-        this->_payload.structure.re2_byte_2
-    );
-}
+uint8_t* Tx::getPayload() {
+    int payload_size = this->getPayloadSize();
+    this->current_payload_size = payload_size;
 
-uint8_t* Tx::getByteArray() {
-    return this->_payload.byteArray;
+    uint8_t* payload_data = (uint8_t*)malloc(this->maximum_payload_size);
+
+    if (payload_data == NULL) {
+        // Handle memory allocation failure
+        return NULL;
+    }
+
+    uint8_t current_position = 0;
+
+    // Add the current config to the payload
+    uint16_t config_encode = Tx::encodeStatusToByte(this->payload_config, 16);
+    payload_data[current_position++] = (config_encode & 0xFF);
+    payload_data[current_position++] = (config_encode >> 8);
+
+    for (int i = 3; i < 16; i++) {
+        if (this->payload_config[i]) {
+            uint8_t first_byte = this->channels[i - 3].first_byte;
+            payload_data[current_position++] = first_byte;
+
+            if (this->channels[i - 3].required_bytes == 2) {
+                uint8_t second_byte = this->channels[i - 3].second_byte;
+                payload_data[current_position++] = second_byte;
+            }
+        }
+    }
+    return payload_data;
 }

--- a/code/RemoteTx/src/tx/tx_utils.cpp
+++ b/code/RemoteTx/src/tx/tx_utils.cpp
@@ -32,18 +32,26 @@ int Tx::joystickMap(
   }
 }
 
-uint16_t Tx::encodeSwitchStatusesToByte(bool switchStatuses[], int numSwitches) {
+uint16_t Tx::combineBytes(uint8_t byte1, uint8_t byte2) {
+  return ((uint16_t)byte2 << 8) | byte1;
+}
+
+void Tx::increasePayloadSize(uint8_t bytes) {
+    this->payload_size += bytes;
+}
+
+uint16_t Tx::encodeStatusToByte(bool statuses[], int num) {
     uint16_t encodedByte = 0;
 
-    for (int i = 0; i < numSwitches; i++) {
-        encodedByte |= (switchStatuses[i] << i);
+    for (int i = 0; i < num; i++) {
+        encodedByte |= (statuses[i] << i);
     }
 
     return encodedByte;
 }
 
-void Tx::decodeByteToSwitchStatuses(uint16_t encodedByte, bool switchStatuses[], int numSwitches) {
-  for (int i = 0; i < numSwitches; i++) {
-    switchStatuses[i] = (encodedByte >> i) & 0x01;
+void Tx::decodeByteToStatus(uint16_t encodedByte, bool statuses[], int num) {
+  for (int i = 0; i < num; i++) {
+    statuses[i] = (encodedByte >> i) & 0x01;
   }
 }

--- a/code/RemoteTx/user_config_bk.hpp
+++ b/code/RemoteTx/user_config_bk.hpp
@@ -1,0 +1,109 @@
+/**
+ * RC Transmitter – ESP32 / SX1280
+ * https://github.com/alx-uta/RC-Transmitter
+ *
+ * Alex Uta
+ * microknot.dev
+ */
+
+#ifndef USER_CONFIG_HPP
+#define USER_CONFIG_HPP
+
+// Debug
+#define ENABLE_SERIAL_PRINT     true
+#define ENABLE_DEBUG            true
+#define ENABLE_RADIO_LIB_DEBUG  true
+
+// Calibration
+uint8_t calibrationReadings     = 100;
+#define ENABLE_CALIBRATION      true
+
+/**
+ * MCP3208
+ */
+#define MCP3208_SPI_SPEED 4000000
+
+/**
+ * MCP23S17T
+ */
+#define MCP23S17T_SPI_SPEED 10000000
+
+// Set the sensitivity value
+uint8_t pot_drift_value = 2;
+uint8_t pot_min = 0;
+int pot_max = 4092;
+uint8_t pot_out_min = 0;
+uint8_t pot_out_max = 255;
+
+/**
+ * Joysticks
+ */
+int
+    // General values
+    joystick_min_out        = 0,
+    joystick_max_out        = 255,
+    joystick_default_value  = 127,
+
+    /**
+     * Left Joystick
+     */
+
+    // X
+    left_joystick_drift_value_x = 20,//18,
+    left_joystick_min_value_x = 718,
+    left_joystick_max_value_x = 2995,
+    left_joystick_middle_value_x = 1884,//1886,
+
+    // Y
+    left_joystick_drift_value_y = 20,//18,
+    left_joystick_min_value_y = 495,
+    left_joystick_max_value_y = 2920,//2940,
+    left_joystick_middle_value_y = 1840,//1847,
+
+    /**
+     * Right Joystick
+     */
+
+    // X
+    right_joystick_drift_value_x = 20,
+    right_joystick_min_value_x = 225,
+    right_joystick_max_value_x = 3320,
+    right_joystick_middle_value_x = 1833, //1833,
+
+    // Y
+    right_joystick_drift_value_y = 20,
+    right_joystick_min_value_y = 660,
+    right_joystick_max_value_y = 3190,//3206,
+    right_joystick_middle_value_y = 1963; //1963;
+
+/**
+ * SX1280
+ */
+
+/*!
+  \brief No shaping.
+*/
+#define RADIOLIB_SHAPING_NONE                                   (0x00)
+
+/*!
+  \brief Gaussian shaping filter, BT = 0.5
+*/
+#define RADIOLIB_SHAPING_0_5                                    (0x02)
+
+/*!
+  \brief Gaussian shaping filter, BT = 1.0
+*/
+#define RADIOLIB_SHAPING_1_0                                    (0x04)
+
+
+float   SX1280_FREQUENCY            = 2400.6;
+float   SX1280_FREQUENCY_DEVIATION  = 800.0;
+int     SX1280_BIT_RATE             = 250; //250;
+int     SX1280_OUTPUT_POWER         = 12; // -18 to 13 dBm
+int     SX1280_GAIN_CONTROL         = 12; // 1 - 13
+uint8_t SX1280_DATA_SHAPING         = RADIOLIB_SHAPING_1_0;
+uint8_t SX1280_SYNC_WORD[]          = {0x09, 0x07, 0x69, 0x01, 0x13};
+int     SX1280_SYNC_WORD_LEN        = 5;
+int     SX1280_CRC_VALUE            = 1;
+int     SX1280_PREAMBLE_LENGTH      = 4;
+#endif  // USER_CONFIG_HPP


### PR DESCRIPTION
- Improve the data rate by only sending the channels when we need to.
- Remove the package from the TX
- Split everything into multiple channels


New defined channels:

- CH1  : Left Joystick Up/Down
- CH2  : Joystick Left/Right
- CH3  : Right Joystick Up/Down
- CH4  : Right Joystick Left/Right
- CH5  : Push Buttons and Switches
- CH6  : Left Rotary Encoder
- CH7  : Right Rotary Encoder
- CH8  : Potentiometer 1
- CH9  : Potentiometer 2
- CH10 : Potentiometer 3
- CH11 : Potentiometer 4
- CH12 : Potentiometer 5
- CH13 : Potentiometer 6